### PR TITLE
Write partial lookup key to S3 index.

### DIFF
--- a/spatialdb/object.py
+++ b/spatialdb/object.py
@@ -293,6 +293,19 @@ class AWSObjectStore(ObjectStore):
 
         return "{}&{}".format(hash_str, base_key)
 
+    @staticmethod
+    def generate_lookup_key(collection_id, experiment_id, channel_id, resolution):
+        """
+        Generate the lookup key for storing as an attribute in the S3 index table.
+
+        This value will be the key of a global secondary index that allows
+        finding all the cuboids belonging to a particular channel in an 
+        efficient manner.
+        """
+        lookup_key = '{}&{}&{}&{}'.format(
+            collection_id, experiment_id, channel_id, resolution)
+        return lookup_key
+
     def cuboids_exist(self, key_list, cache_miss_key_idx=None, version=0):
         """
         Method to check if cuboids exist in S3 by checking the S3 Index table.
@@ -362,7 +375,7 @@ class AWSObjectStore(ObjectStore):
 
         # Partial lookup key stored so we can use a Dynamo query to find all cuboids
         # tha belong to a channel.
-        lookup_key = '{}&{}&{}&{}'.format(
+        lookup_key = self.generate_lookup_key(
             parts.collection_id, parts.experiment_id, parts.channel_id,
             parts.resolution)
 

--- a/spatialdb/object.py
+++ b/spatialdb/object.py
@@ -360,13 +360,22 @@ class AWSObjectStore(ObjectStore):
         # range key is exp&ch&res&task
         ingest_job_range = "{}&{}&{}&{}".format(parts.experiment_id, parts.channel_id, parts.resolution, ingest_job)
 
+        # Partial lookup key stored so we can use a Dynamo query to find all cuboids
+        # tha belong to a channel.
+        lookup_key = '{}&{}&{}&{}'.format(
+            parts.collection_id, parts.experiment_id, parts.channel_id,
+            parts.resolution)
+
         try:
             dynamodb.put_item(
                 TableName=self.config['s3_index_table'],
-                Item={'object-key': {'S': object_key},
+                Item={
+                    'object-key': {'S': object_key},
                       'version-node': {'N': "{}".format(version)},
                       'ingest-job-hash': {'S': "{}".format(parts.collection_id)},
-                      'ingest-job-range': {'S': ingest_job_range}},
+                      'ingest-job-range': {'S': ingest_job_range},
+                      'lookup-key': {'S': lookup_key}
+                },
                 ReturnConsumedCapacity='NONE',
                 ReturnItemCollectionMetrics='NONE',
             )

--- a/spatialdb/test/test_AWS_object_store.py
+++ b/spatialdb/test/test_AWS_object_store.py
@@ -143,6 +143,7 @@ class AWSObjectStoreTestMixin(object):
         assert response['Item']['version-node']['N'] == "0"
         assert response['Item']['ingest-job-hash']['S'] == '1'
         assert response['Item']['ingest-job-range']['S'] == '1&1&0&0'
+        assert response['Item']['lookup-key']['S'] == '1&1&1&0'
 
     def test_cuboids_exist(self):
         """Test method for checking if cuboids exist in S3 index"""

--- a/spatialdb/test/test_AWS_object_store.py
+++ b/spatialdb/test/test_AWS_object_store.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import patch
 
 from spdb.project import BossResourceBasic
 from spdb.spatialdb import AWSObjectStore
@@ -23,12 +24,13 @@ from bossutils import configuration
 from spdb.spatialdb.test.setup import SetupTests
 
 import boto3
-from bossutils.aws import get_region
+#from bossutils.aws import get_region
 
 
+@patch('spdb.spatialdb.object.get_region', autospec=True, return_value='us-east-1')
 class AWSObjectStoreTestMixin(object):
 
-    def test_object_key_chunks(self):
+    def test_object_key_chunks(self, fake_get_region):
         """Test method to return object keys in chunks"""
         keys = ['1', '2', '3', '4', '5', '6', '7']
         expected = [['1', '2', '3'],
@@ -38,14 +40,14 @@ class AWSObjectStoreTestMixin(object):
         for cnt, chunk in enumerate(AWSObjectStore.object_key_chunks(keys, 3)):
             assert chunk == expected[cnt]
 
-    def test_generate_object_keys(self):
+    def test_generate_object_keys(self, fake_get_region):
         """Test to create object keys"""
         os = AWSObjectStore(self.object_store_config)
         object_keys = os.generate_object_key(self.resource, 0, 2, 56)
 
         assert object_keys == '631424bf68302b683a0be521101c192b&4&3&2&0&2&56'
 
-    def test_get_object_keys(self):
+    def test_get_object_keys(self, fake_get_region):
         os = AWSObjectStore(self.object_store_config)
         cuboid_bounds = Region.Cuboids(range(2, 3), range(2, 3), range(2, 3))
         resolution = 0
@@ -57,7 +59,7 @@ class AWSObjectStoreTestMixin(object):
         assert expected == actual
 
 
-    def test_cached_cuboid_to_object_keys(self):
+    def test_cached_cuboid_to_object_keys(self, fake_get_region):
         """Test to check key conversion from cached cuboid to object"""
 
         cached_cuboid_keys = ["CACHED-CUBOID&1&1&1&0&0&12", "CACHED-CUBOID&1&1&1&0&0&13"]
@@ -69,7 +71,7 @@ class AWSObjectStoreTestMixin(object):
         assert object_keys[0] == '6b5ebb14395dec6cd9d7edaa1fbcd748&1&1&1&0&0&12'
         assert object_keys[1] == '592ed5f40528bb16bce769fed5b2e9c6&1&1&1&0&0&13'
 
-    def test_cached_cuboid_to_object_keys_str(self):
+    def test_cached_cuboid_to_object_keys_str(self, fake_get_region):
         """Test to check key conversion from cached cuboid to object"""
 
         cached_cuboid_keys = "CACHED-CUBOID&1&1&1&0&0&12"
@@ -80,7 +82,7 @@ class AWSObjectStoreTestMixin(object):
         assert len(object_keys) == 1
         assert object_keys[0] == '6b5ebb14395dec6cd9d7edaa1fbcd748&1&1&1&0&0&12'
 
-    def test_write_cuboid_to_object_keys(self):
+    def test_write_cuboid_to_object_keys(self, fake_get_region):
         """Test to check key conversion from cached cuboid to object"""
 
         write_cuboid_keys = ["WRITE-CUBOID&1&1&1&0&0&12&SDFJlskDJasdfniasdf",
@@ -93,7 +95,7 @@ class AWSObjectStoreTestMixin(object):
         assert object_keys[0] == '6b5ebb14395dec6cd9d7edaa1fbcd748&1&1&1&0&0&12'
         assert object_keys[1] == '592ed5f40528bb16bce769fed5b2e9c6&1&1&1&0&0&13'
 
-    def test_write_cuboid_to_object_atr(self):
+    def test_write_cuboid_to_object_atr(self, fake_get_region):
         """Test to check key conversion from cached cuboid to object when a string instead of a list is passed"""
 
         write_cuboid_keys = "WRITE-CUBOID&1&1&1&0&0&12&SDFJlskDJasdfniasdf"
@@ -104,7 +106,7 @@ class AWSObjectStoreTestMixin(object):
         assert len(object_keys) == 1
         assert object_keys[0] == '6b5ebb14395dec6cd9d7edaa1fbcd748&1&1&1&0&0&12'
 
-    def test_object_to_cached_cuboid_keys(self):
+    def test_object_to_cached_cuboid_keys(self, fake_get_region):
         """Test to check key conversion from cached cuboid to object"""
 
         object_keys = ['a4931d58076dc47773957809380f206e4228517c9fa6daed536043782024e480&1&1&1&0&0&12',
@@ -113,7 +115,7 @@ class AWSObjectStoreTestMixin(object):
         os = AWSObjectStore(self.object_store_config)
         cached_cuboid_keys = os.object_to_cached_cuboid_keys(object_keys)
 
-    def test_object_to_cached_cuboid_keys_str(self):
+    def test_object_to_cached_cuboid_keys_str(self, fake_get_region):
         """Test to check key conversion from cached cuboid to object when a string instead of a list is passed"""
 
         object_keys = 'a4931d58076dc47773957809380f206e4228517c9fa6daed536043782024e480&1&1&1&0&0&12'
@@ -124,14 +126,14 @@ class AWSObjectStoreTestMixin(object):
         assert len(cached_cuboid_keys) == 1
         assert cached_cuboid_keys[0] == "CACHED-CUBOID&1&1&1&0&0&12"
 
-    def test_add_cuboid_to_index(self):
+    def test_add_cuboid_to_index(self, fake_get_region):
         """Test method to compute final object key and add to S3"""
         dummy_key = "SLDKFJDSHG&1&1&1&0&0&12"
         os = AWSObjectStore(self.object_store_config)
         os.add_cuboid_to_index(dummy_key)
 
         # Get item
-        dynamodb = boto3.client('dynamodb', region_name=get_region())
+        dynamodb = boto3.client('dynamodb', region_name=fake_get_region())
         response = dynamodb.get_item(
             TableName=self.object_store_config['s3_index_table'],
             Key={'object-key': {'S': dummy_key},
@@ -145,7 +147,7 @@ class AWSObjectStoreTestMixin(object):
         assert response['Item']['ingest-job-range']['S'] == '1&1&0&0'
         assert response['Item']['lookup-key']['S'] == '1&1&1&0'
 
-    def test_cuboids_exist(self):
+    def test_cuboids_exist(self, fake_get_region):
         """Test method for checking if cuboids exist in S3 index"""
         os = AWSObjectStore(self.object_store_config)
 
@@ -165,7 +167,7 @@ class AWSObjectStoreTestMixin(object):
         assert exist_keys == [1, 2]
         assert missing_keys == [0, 3]
 
-    def test_cuboids_exist_with_cache_miss(self):
+    def test_cuboids_exist_with_cache_miss(self, fake_get_region):
         """Test method for checking if cuboids exist in S3 index while supporting
         the cache miss key index parameter"""
         os = AWSObjectStore(self.object_store_config)
@@ -186,7 +188,7 @@ class AWSObjectStoreTestMixin(object):
         assert exist_keys == [1, 2]
         assert missing_keys == []
 
-    def test_put_get_single_object(self):
+    def test_put_get_single_object(self, fake_get_region):
         """Method to test putting and getting objects to and from S3"""
         os = AWSObjectStore(self.object_store_config)
 
@@ -200,7 +202,7 @@ class AWSObjectStoreTestMixin(object):
         returned_data = os.get_single_object(object_keys[0])
         assert fake_data[0] == returned_data
 
-    def test_put_get_objects_syncronous(self):
+    def test_put_get_objects_syncronous(self, fake_get_region):
         """Method to test putting and getting objects to and from S3"""
         os = AWSObjectStore(self.object_store_config)
 
@@ -215,7 +217,7 @@ class AWSObjectStoreTestMixin(object):
         for rdata, sdata in zip(returned_data, fake_data):
             assert rdata == sdata
 
-    def test_get_object_key_parts(self):
+    def test_get_object_key_parts(self, fake_get_region):
         """Test to get an object key parts"""
         os = AWSObjectStore(self.object_store_config)
         object_key = os.generate_object_key(self.resource, 0, 2, 56)
@@ -232,14 +234,14 @@ class AWSObjectStoreTestMixin(object):
         self.assertEqual(parts.morton_id, "56")
         self.assertEqual(parts.is_iso, False)
 
-    def test_generate_object_keys_iso_anisotropic_below_fork(self):
+    def test_generate_object_keys_iso_anisotropic_below_fork(self, fake_get_region):
         """Test to create object key when asking for isotropic data, in an anisotropic channel, below the iso fork"""
         os = AWSObjectStore(self.object_store_config)
         object_keys = os.generate_object_key(self.resource, 0, 2, 56, iso=True)
 
         assert object_keys == '631424bf68302b683a0be521101c192b&4&3&2&0&2&56'
 
-    def test_generate_object_keys_iso_anisotropic_above_fork(self):
+    def test_generate_object_keys_iso_anisotropic_above_fork(self, fake_get_region):
         """Test to create object key when asking for isotropic data, in an anisotropic channel, above the iso fork"""
         os = AWSObjectStore(self.object_store_config)
         object_keys = os.generate_object_key(self.resource, 3, 2, 56, iso=True)
@@ -248,7 +250,7 @@ class AWSObjectStoreTestMixin(object):
         object_keys = os.generate_object_key(self.resource, 5, 2, 56, iso=True)
         assert object_keys == '068e7246f31aacac92ca74923b9da6f1&ISO&4&3&2&5&2&56'
 
-    def test_generate_object_keys_iso_isotropic(self):
+    def test_generate_object_keys_iso_isotropic(self, fake_get_region):
         """Test to create object key when asking for isotropic data, in an isotropic channel"""
         data = self.setup_helper.get_image8_dict()
         data['experiment']['hierarchy_method'] = "isotropic"
@@ -265,7 +267,7 @@ class AWSObjectStoreTestMixin(object):
         object_keys = os.generate_object_key(resource, 5, 2, 56, iso=True)
         assert object_keys == '831adead1bc05b24d0799206ee9fe832&4&3&2&5&2&56'
 
-    def test_get_object_key_parts_iso(self):
+    def test_get_object_key_parts_iso(self, fake_get_region):
         """Test to get an object key parts after the iso split on an anisotropic channel"""
         os = AWSObjectStore(self.object_store_config)
         object_key = os.generate_object_key(self.resource, 5, 2, 56, iso=True)
@@ -306,8 +308,10 @@ class TestAWSObjectStore(AWSObjectStoreTestMixin, unittest.TestCase):
 
         # Create AWS Resources needed for tests
         cls.setup_helper.start_mocking()
-        cls.setup_helper.create_index_table(cls.object_store_config["s3_index_table"], cls.setup_helper.DYNAMODB_SCHEMA)
-        cls.setup_helper.create_cuboid_bucket(cls.object_store_config["cuboid_bucket"])
+        with patch('spdb.spatialdb.test.setup.get_region') as fake_get_region:
+            fake_get_region.return_value = 'us-east-1'
+            cls.setup_helper.create_index_table(cls.object_store_config["s3_index_table"], cls.setup_helper.DYNAMODB_SCHEMA)
+            cls.setup_helper.create_cuboid_bucket(cls.object_store_config["cuboid_bucket"])
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Store partial lookup key as attribute so it's possible to use a Dynamo
query to find all cuboids that belong to a channel.  Without this info,
will have to do a Dynamo table scan to find all cuboids.