### PR TITLE
Id index update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ target/
 addData.o
 c_lib/c_version/*.o
 c_lib/c_version/makefile
+
+# Vim files
+*.swp
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ mockredispy==2.9.3
 blosc==1.2.8
 nose2
 numpy==1.11.1
-moto
+moto>=1.1.24
 boto3
 hvac

--- a/spatialdb/dynamo/id_index_schema.json
+++ b/spatialdb/dynamo/id_index_schema.json
@@ -17,6 +17,28 @@
         {
             "AttributeName": "version",
             "AttributeType": "N"
+        },
+        {
+            "AttributeName": "lookup-key",
+            "AttributeType": "S"
+        }
+    ],
+    "GlobalSecondaryIndexes": [
+        {
+            "IndexName": "lookup-key-index",
+            "KeySchema": [
+                {
+                    "AttributeName": "lookup-key",
+                    "KeyType": "HASH"
+                }
+            ],
+            "Projection": {
+                "ProjectionType": "KEYS_ONLY"
+            },
+            "ProvisionedThroughput": {
+                "ReadCapacityUnits": 15,
+                "WriteCapacityUnits": 15
+            }
         }
     ],
     "ProvisionedThroughput":{

--- a/spatialdb/dynamo/id_index_table.md
+++ b/spatialdb/dynamo/id_index_table.md
@@ -17,11 +17,11 @@ contain a given annotation id.
 
 ## Global Secondary Indexes
 
-### project-index
+### lookup-key-index
 
 **This index is under consideration, but not yet created.**
 
-Easily find all ids belonging to a particular collection, experiment, channel, 
+Easily find all ids belonging to a particular collection, experiment, channel,
 and resolution.
 
 Potential use case: deleting ids belonging to a deleted channel.

--- a/spatialdb/dynamo/id_index_table.md
+++ b/spatialdb/dynamo/id_index_table.md
@@ -1,0 +1,35 @@
+# Id Index
+
+This Dynamo table maps annotation ids to the cuboids they exist in.  Using
+this table, it is easy to return a cutout that contains all the cuboids that
+contain a given annotation id.
+
+## Key
+
+`channel-id-key` (S): key formed by the collection | experiment | channel | resolution | annotation id
+`version` (N): range key (reserved for future use)
+
+## Attributes
+
+`cuboid-set` (SS): Set of all morton ids of the cuboids that the annotation id exists in
+`lookup-key` (S): stores the collection | experiment | channel | resolution of the cuboid
+
+
+## Global Secondary Indexes
+
+### project-index
+
+**This index is under consideration, but not yet created.**
+
+Easily find all ids belonging to a particular collection, experiment, channel, 
+and resolution.
+
+Potential use case: deleting ids belonging to a deleted channel.
+
+##### Key
+
+`lookup-key`
+
+#### Projected Attributes
+
+None

--- a/spatialdb/dynamo/s3_index_table.json
+++ b/spatialdb/dynamo/s3_index_table.json
@@ -15,6 +15,10 @@
         {
             "AttributeName": "ingest-job-range",
             "AttributeType": "S"
+        },
+        {
+            "AttributeName": "lookup-key",
+            "AttributeType": "S"
         }
     ],
     "KeySchema": [
@@ -38,6 +42,22 @@
                 {
                     "AttributeName": "ingest-job-range",
                     "KeyType": "RANGE"
+                }
+            ],
+            "Projection": {
+                "ProjectionType": "KEYS_ONLY"
+            },
+            "ProvisionedThroughput": {
+                "ReadCapacityUnits": 15,
+                "WriteCapacityUnits": 15
+            }
+        },
+        {
+            "IndexName": "lookup-key-index",
+            "KeySchema": [
+                {
+                    "AttributeName": "lookup-key",
+                    "KeyType": "HASH"
                 }
             ],
             "Projection": {

--- a/spatialdb/dynamo/s3_index_table.md
+++ b/spatialdb/dynamo/s3_index_table.md
@@ -33,7 +33,7 @@ Find cuboids based on the ingest job.
 None
 
 
-### project-index
+### lookup-key-index
 
 Find all cuboids in a collection, experiment, channel at a resolution level.
 

--- a/spatialdb/dynamo/s3_index_table.md
+++ b/spatialdb/dynamo/s3_index_table.md
@@ -1,0 +1,46 @@
+# S3 Index
+
+This Dynamo table tracks which cuboids exist in S3 cuboid bucket.  If the
+cuboid belongs to an annotation channel, it also has a set that contains all
+the annotation ids that exist inside the cuboid.
+
+## Key
+
+`object-key` (S): same key used in the S3 cuboid bucket
+`version-node` (N): range key (reserved for future use)
+
+## Attributes
+
+`ingest-job-hash` (S): the collection id
+`ingest-job-range` (S): the id of the ingest job that this cuboid was part of
+`id-set` (SS): Set of all annotation ids that exist in the cuboid if this is part of an annotation channel
+`lookup-key` (S): stores the collection | experiment | channel | resolution of the cuboid
+
+
+## Global Secondary Indexes
+
+### ingest-job-index
+
+Find cuboids based on the ingest job.
+
+#### Key
+
+`ingest-job-hash`
+`ingest-job-range` (range)
+
+#### Projected Attributes
+
+None
+
+
+### project-index
+
+Find all cuboids in a collection, experiment, channel at a resolution level.
+
+##### Key
+
+`lookup-key`
+
+#### Projected Attributes
+
+None

--- a/spatialdb/object_indices.py
+++ b/spatialdb/object_indices.py
@@ -780,8 +780,13 @@ class ObjectIndices:
             chunk_num = 0
             rev_id = None
 
-        actual_chunk = self.write_cuboid(
-            max_used_capacity, cuboid_morton, key, chunk_num, rev_id, version)
+        try:
+            actual_chunk = self.write_cuboid(
+                max_used_capacity, cuboid_morton, key, chunk_num, rev_id, version)
+        except:
+            print('Failed to update key: {} with morton id: {}'.format(
+                key, cuboid_morton))
+            raise
 
         if actual_chunk > chunk_num:
             self.update_last_partition_key(key, actual_chunk, version)

--- a/spatialdb/object_indices.py
+++ b/spatialdb/object_indices.py
@@ -990,7 +990,9 @@ class ObjectIndices:
         """
 
         # Expression attribute value for the revision id.
-        REV_VALUE = ':revId'
+        CURRENT_REV_VALUE = ':currentRevId'
+
+        NEW_REV_VALUE = ':newRevId'
 
         update_args = {
             'TableName': self.id_index_table,
@@ -1000,7 +1002,7 @@ class ObjectIndices:
             },
             'UpdateExpression':
                 'ADD #cuboidset :objkey SET {} = {}, #lookupKey = if_not_exists(#lookupKey, :lookupKeyVal)'.format(
-                    REV_ID, REV_VALUE),
+                    REV_ID, NEW_REV_VALUE),
             'ExpressionAttributeNames': {
                 '#cuboidset': 'cuboid-set', 
                 '#lookupKey': LOOKUP_KEY
@@ -1014,13 +1016,15 @@ class ObjectIndices:
 
         if rev_id is not None:
             update_args['ConditionExpression'] = (
-                'attribute_exists({0}) AND {0} = {1}'.format(REV_ID, REV_VALUE))
-            update_args['ExpressionAttributeValues'][REV_VALUE] = (
+                'attribute_exists({0}) AND {0} = {1}'.format(REV_ID, CURRENT_REV_VALUE))
+            update_args['ExpressionAttributeValues'][CURRENT_REV_VALUE] = (
                 {'N': str(rev_id)})
+            update_args['ExpressionAttributeValues'][NEW_REV_VALUE] = (
+                {'N': str(rev_id+1)})
         else:
             update_args['ConditionExpression'] = (
                 'attribute_not_exists({0})'.format(REV_ID))
-            update_args['ExpressionAttributeValues'][REV_VALUE] = {'N': '0'}
+            update_args['ExpressionAttributeValues'][NEW_REV_VALUE] = {'N': '0'}
 
         # Do DynamoDB set add op.
         response = self.dynamodb.update_item(**update_args)

--- a/spatialdb/object_indices.py
+++ b/spatialdb/object_indices.py
@@ -777,7 +777,8 @@ class ObjectIndices:
                 return
         except KeyError:
             # No key exists in table for this id.
-            pass
+            chunk_num = 0
+            rev_id = None
 
         actual_chunk = self.write_cuboid(
             max_used_capacity, cuboid_morton, key, chunk_num, rev_id, version)

--- a/spatialdb/object_indices.py
+++ b/spatialdb/object_indices.py
@@ -47,7 +47,7 @@ LOOKUP_KEY = 'lookup-key'
 class ObjectIndices:
     """
     Class that handles the DynamoDB tracking of object IDs.  This class
-    supports the AWS Object Store.  The table name is idIndex.domain.boss.
+    supports the AWS Object Store.  The table name is idIndex.domain.tld.
     """
 
     def __init__(
@@ -940,7 +940,7 @@ class ObjectIndices:
             (int): chunk that the morton id was written to.
         """
         new_chunk_num = chunk_num
-        exp_rev_id = rev_id
+        expected_rev_id = rev_id
 
         done = False
 
@@ -952,7 +952,7 @@ class ObjectIndices:
 
             try:
                 response = self.write_cuboid_dynamo(
-                    cuboid_morton, dynamo_key, exp_rev_id, lookup_key, version)
+                    cuboid_morton, dynamo_key, expected_rev_id, lookup_key, version)
                 if 'ConsumedCapacity' in response:
                     used = response['ConsumedCapacity']['CapacityUnits']
                     if used >= max_used_capacity:
@@ -968,7 +968,7 @@ class ObjectIndices:
                 ):
                     # Set full, try the next chunk.
                     new_chunk_num = new_chunk_num + 1
-                    exp_rev_id = None
+                    expected_rev_id = None
                     print('Incrementing chunk number to {}, item size exceeded'.format(
                         new_chunk_num))
                 else:

--- a/spatialdb/test/int_test_object_indices.py
+++ b/spatialdb/test/int_test_object_indices.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from spdb.spatialdb import AWSObjectStore
 from spdb.spatialdb.object_indices import ObjectIndices
 from spdb.c_lib.ndlib import XYZMorton
 from spdb.c_lib.ndtype import CUBOIDSIZE
@@ -155,7 +156,7 @@ class TestObjectIndicesWithDynamoDb(unittest.TestCase):
         resolution = 1
         time_sample = 0
         morton_id = 20
-        object_key = self.obj_store.generate_object_key(
+        object_key = AWSObjectStore.generate_object_key(
             resource, resolution, time_sample, morton_id)
 
         # Method under test.
@@ -192,7 +193,7 @@ class TestObjectIndicesWithDynamoDb(unittest.TestCase):
         resolution = 1
         time_sample = 0
         morton_id = 20
-        object_key = self.obj_store.generate_object_key(
+        object_key = AWSObjectStore.generate_object_key(
             resource, resolution, time_sample, morton_id)
 
         self.obj_ind.update_id_indices(resource, resolution, [object_key], [bytes], version)
@@ -203,7 +204,7 @@ class TestObjectIndicesWithDynamoDb(unittest.TestCase):
         new_bytes[3] = 55       # Pre-existing id.
 
         new_morton_id = 90
-        new_object_key = self.obj_store.generate_object_key(
+        new_object_key = AWSObjectStore.generate_object_key(
             resource, resolution, time_sample, new_morton_id)
 
         # Method under test.
@@ -251,7 +252,7 @@ class TestObjectIndicesWithDynamoDb(unittest.TestCase):
         time_sample = 0
         resource = BossResourceBasic(data=get_anno_dict())
         mortonid = XYZMorton([0, 0, 0])
-        obj_keys = [self.obj_store.generate_object_key(resource, resolution, time_sample, mortonid)]
+        obj_keys = [AWSObjectStore.generate_object_key(resource, resolution, time_sample, mortonid)]
         cubes = [np.random.randint(2000000, size=(16, 512, 512), dtype='uint64')]
 
         # If too many ids, the index is skipped, logged, and False is returned to the caller.
@@ -275,7 +276,7 @@ class TestObjectIndicesWithDynamoDb(unittest.TestCase):
         resolution = 1
         time_sample = 0
         morton_id = 2000
-        object_key = self.obj_store.generate_object_key(
+        object_key = AWSObjectStore.generate_object_key(
             resource, resolution, time_sample, morton_id)
 
         # Write a legacy index
@@ -317,7 +318,7 @@ class TestObjectIndicesWithDynamoDb(unittest.TestCase):
 
         for x in range(0, 7651):
             mortonid = XYZMorton([x, y, z])
-            obj_keys.append(self.obj_store.generate_object_key(
+            obj_keys.append(AWSObjectStore.generate_object_key(
                 resource, resolution, time_sample, mortonid))
             # Just need one non-zero number to represent each cuboid.
             cubes.append(np.ones(1, dtype='uint64'))
@@ -333,13 +334,13 @@ class TestObjectIndicesWithDynamoDb(unittest.TestCase):
         bytes = np.zeros(10, dtype='uint64')
         bytes[1] = id
         resolution = 1
-        key = self.obj_store.generate_object_key(resource, resolution, 0, 56)
+        key = AWSObjectStore.generate_object_key(resource, resolution, 0, 56)
         version = 0
         resource = BossResourceBasic(data=get_anno_dict())
 
         new_bytes = np.zeros(4, dtype='uint64')
         new_bytes[0] = id     # Pre-existing id.
-        new_key = self.obj_store.generate_object_key(resource, resolution, 0, 59)
+        new_key = AWSObjectStore.generate_object_key(resource, resolution, 0, 59)
 
         self.obj_ind.update_id_indices(
             resource, resolution, [key, new_key], [bytes, new_bytes], version)
@@ -363,7 +364,7 @@ class TestObjectIndicesWithDynamoDb(unittest.TestCase):
         pos0 = [x_cube_dim, 2*y_cube_dim, 3*z_cube_dim]
         pos_ind0 = [pos0[0]/x_cube_dim, pos0[1]/y_cube_dim, pos0[2]/z_cube_dim]
         morton_id0 = XYZMorton(pos_ind0)
-        key0 = self.obj_store.generate_object_key(
+        key0 = AWSObjectStore.generate_object_key(
             self.resource, resolution, time_sample, morton_id0)
 
         bytes1 = np.zeros(4, dtype='uint64')
@@ -371,7 +372,7 @@ class TestObjectIndicesWithDynamoDb(unittest.TestCase):
         pos1 = [3*x_cube_dim, 5*y_cube_dim, 6*z_cube_dim]
         pos_ind1 = [pos1[0]/x_cube_dim, pos1[1]/y_cube_dim, pos1[2]/z_cube_dim]
         morton_id1 = XYZMorton(pos_ind1)
-        key1 = self.obj_store.generate_object_key(
+        key1 = AWSObjectStore.generate_object_key(
             self.resource, resolution, time_sample, morton_id1)
 
         self.obj_ind.update_id_indices(

--- a/spatialdb/test/test_AWS_object_store.py
+++ b/spatialdb/test/test_AWS_object_store.py
@@ -23,12 +23,12 @@ from bossutils import configuration
 from spdb.spatialdb.test.setup import SetupTests
 
 import boto3
-from bossutils.aws import get_region
+from unittest.mock import patch
 
 
 class AWSObjectStoreTestMixin(object):
 
-    def test_object_key_chunks(self):
+    def test_object_key_chunks(self, fake_get_region):
         """Test method to return object keys in chunks"""
         keys = ['1', '2', '3', '4', '5', '6', '7']
         expected = [['1', '2', '3'],
@@ -38,14 +38,14 @@ class AWSObjectStoreTestMixin(object):
         for cnt, chunk in enumerate(AWSObjectStore.object_key_chunks(keys, 3)):
             assert chunk == expected[cnt]
 
-    def test_generate_object_keys(self):
+    def test_generate_object_keys(self, fake_get_region):
         """Test to create object keys"""
         os = AWSObjectStore(self.object_store_config)
         object_keys = os.generate_object_key(self.resource, 0, 2, 56)
 
         assert object_keys == '631424bf68302b683a0be521101c192b&4&3&2&0&2&56'
 
-    def test_get_object_keys(self):
+    def test_get_object_keys(self, fake_get_region):
         os = AWSObjectStore(self.object_store_config)
         cuboid_bounds = Region.Cuboids(range(2, 3), range(2, 3), range(2, 3))
         resolution = 0
@@ -57,7 +57,7 @@ class AWSObjectStoreTestMixin(object):
         assert expected == actual
 
 
-    def test_cached_cuboid_to_object_keys(self):
+    def test_cached_cuboid_to_object_keys(self, fake_get_region):
         """Test to check key conversion from cached cuboid to object"""
 
         cached_cuboid_keys = ["CACHED-CUBOID&1&1&1&0&0&12", "CACHED-CUBOID&1&1&1&0&0&13"]
@@ -69,7 +69,7 @@ class AWSObjectStoreTestMixin(object):
         assert object_keys[0] == '6b5ebb14395dec6cd9d7edaa1fbcd748&1&1&1&0&0&12'
         assert object_keys[1] == '592ed5f40528bb16bce769fed5b2e9c6&1&1&1&0&0&13'
 
-    def test_cached_cuboid_to_object_keys_str(self):
+    def test_cached_cuboid_to_object_keys_str(self, fake_get_region):
         """Test to check key conversion from cached cuboid to object"""
 
         cached_cuboid_keys = "CACHED-CUBOID&1&1&1&0&0&12"
@@ -80,7 +80,7 @@ class AWSObjectStoreTestMixin(object):
         assert len(object_keys) == 1
         assert object_keys[0] == '6b5ebb14395dec6cd9d7edaa1fbcd748&1&1&1&0&0&12'
 
-    def test_write_cuboid_to_object_keys(self):
+    def test_write_cuboid_to_object_keys(self, fake_get_region):
         """Test to check key conversion from cached cuboid to object"""
 
         write_cuboid_keys = ["WRITE-CUBOID&1&1&1&0&0&12&SDFJlskDJasdfniasdf",
@@ -93,7 +93,7 @@ class AWSObjectStoreTestMixin(object):
         assert object_keys[0] == '6b5ebb14395dec6cd9d7edaa1fbcd748&1&1&1&0&0&12'
         assert object_keys[1] == '592ed5f40528bb16bce769fed5b2e9c6&1&1&1&0&0&13'
 
-    def test_write_cuboid_to_object_atr(self):
+    def test_write_cuboid_to_object_atr(self, fake_get_region):
         """Test to check key conversion from cached cuboid to object when a string instead of a list is passed"""
 
         write_cuboid_keys = "WRITE-CUBOID&1&1&1&0&0&12&SDFJlskDJasdfniasdf"
@@ -104,7 +104,7 @@ class AWSObjectStoreTestMixin(object):
         assert len(object_keys) == 1
         assert object_keys[0] == '6b5ebb14395dec6cd9d7edaa1fbcd748&1&1&1&0&0&12'
 
-    def test_object_to_cached_cuboid_keys(self):
+    def test_object_to_cached_cuboid_keys(self, fake_get_region):
         """Test to check key conversion from cached cuboid to object"""
 
         object_keys = ['a4931d58076dc47773957809380f206e4228517c9fa6daed536043782024e480&1&1&1&0&0&12',
@@ -113,7 +113,7 @@ class AWSObjectStoreTestMixin(object):
         os = AWSObjectStore(self.object_store_config)
         cached_cuboid_keys = os.object_to_cached_cuboid_keys(object_keys)
 
-    def test_object_to_cached_cuboid_keys_str(self):
+    def test_object_to_cached_cuboid_keys_str(self, fake_get_region):
         """Test to check key conversion from cached cuboid to object when a string instead of a list is passed"""
 
         object_keys = 'a4931d58076dc47773957809380f206e4228517c9fa6daed536043782024e480&1&1&1&0&0&12'
@@ -124,14 +124,14 @@ class AWSObjectStoreTestMixin(object):
         assert len(cached_cuboid_keys) == 1
         assert cached_cuboid_keys[0] == "CACHED-CUBOID&1&1&1&0&0&12"
 
-    def test_add_cuboid_to_index(self):
+    def test_add_cuboid_to_index(self, fake_get_region):
         """Test method to compute final object key and add to S3"""
         dummy_key = "SLDKFJDSHG&1&1&1&0&0&12"
         os = AWSObjectStore(self.object_store_config)
         os.add_cuboid_to_index(dummy_key)
 
         # Get item
-        dynamodb = boto3.client('dynamodb', region_name=get_region())
+        dynamodb = boto3.client('dynamodb', region_name='us-east-1')
         response = dynamodb.get_item(
             TableName=self.object_store_config['s3_index_table'],
             Key={'object-key': {'S': dummy_key},
@@ -144,7 +144,7 @@ class AWSObjectStoreTestMixin(object):
         assert response['Item']['ingest-job-hash']['S'] == '1'
         assert response['Item']['ingest-job-range']['S'] == '1&1&0&0'
 
-    def test_cuboids_exist(self):
+    def test_cuboids_exist(self, fake_get_region):
         """Test method for checking if cuboids exist in S3 index"""
         os = AWSObjectStore(self.object_store_config)
 
@@ -164,7 +164,7 @@ class AWSObjectStoreTestMixin(object):
         assert exist_keys == [1, 2]
         assert missing_keys == [0, 3]
 
-    def test_cuboids_exist_with_cache_miss(self):
+    def test_cuboids_exist_with_cache_miss(self, fake_get_region):
         """Test method for checking if cuboids exist in S3 index while supporting
         the cache miss key index parameter"""
         os = AWSObjectStore(self.object_store_config)
@@ -185,7 +185,7 @@ class AWSObjectStoreTestMixin(object):
         assert exist_keys == [1, 2]
         assert missing_keys == []
 
-    def test_put_get_single_object(self):
+    def test_put_get_single_object(self, fake_get_region):
         """Method to test putting and getting objects to and from S3"""
         os = AWSObjectStore(self.object_store_config)
 
@@ -199,7 +199,7 @@ class AWSObjectStoreTestMixin(object):
         returned_data = os.get_single_object(object_keys[0])
         assert fake_data[0] == returned_data
 
-    def test_put_get_objects_syncronous(self):
+    def test_put_get_objects_syncronous(self, fake_get_region):
         """Method to test putting and getting objects to and from S3"""
         os = AWSObjectStore(self.object_store_config)
 
@@ -214,7 +214,7 @@ class AWSObjectStoreTestMixin(object):
         for rdata, sdata in zip(returned_data, fake_data):
             assert rdata == sdata
 
-    def test_get_object_key_parts(self):
+    def test_get_object_key_parts(self, fake_get_region):
         """Test to get an object key parts"""
         os = AWSObjectStore(self.object_store_config)
         object_key = os.generate_object_key(self.resource, 0, 2, 56)
@@ -231,14 +231,14 @@ class AWSObjectStoreTestMixin(object):
         self.assertEqual(parts.morton_id, "56")
         self.assertEqual(parts.is_iso, False)
 
-    def test_generate_object_keys_iso_anisotropic_below_fork(self):
+    def test_generate_object_keys_iso_anisotropic_below_fork(self, fake_get_region):
         """Test to create object key when asking for isotropic data, in an anisotropic channel, below the iso fork"""
         os = AWSObjectStore(self.object_store_config)
         object_keys = os.generate_object_key(self.resource, 0, 2, 56, iso=True)
 
         assert object_keys == '631424bf68302b683a0be521101c192b&4&3&2&0&2&56'
 
-    def test_generate_object_keys_iso_anisotropic_above_fork(self):
+    def test_generate_object_keys_iso_anisotropic_above_fork(self, fake_get_region):
         """Test to create object key when asking for isotropic data, in an anisotropic channel, above the iso fork"""
         os = AWSObjectStore(self.object_store_config)
         object_keys = os.generate_object_key(self.resource, 3, 2, 56, iso=True)
@@ -247,7 +247,7 @@ class AWSObjectStoreTestMixin(object):
         object_keys = os.generate_object_key(self.resource, 5, 2, 56, iso=True)
         assert object_keys == '068e7246f31aacac92ca74923b9da6f1&ISO&4&3&2&5&2&56'
 
-    def test_generate_object_keys_iso_isotropic(self):
+    def test_generate_object_keys_iso_isotropic(self, fake_get_region):
         """Test to create object key when asking for isotropic data, in an isotropic channel"""
         data = self.setup_helper.get_image8_dict()
         data['experiment']['hierarchy_method'] = "isotropic"
@@ -264,7 +264,7 @@ class AWSObjectStoreTestMixin(object):
         object_keys = os.generate_object_key(resource, 5, 2, 56, iso=True)
         assert object_keys == '831adead1bc05b24d0799206ee9fe832&4&3&2&5&2&56'
 
-    def test_get_object_key_parts_iso(self):
+    def test_get_object_key_parts_iso(self, fake_get_region):
         """Test to get an object key parts after the iso split on an anisotropic channel"""
         os = AWSObjectStore(self.object_store_config)
         object_key = os.generate_object_key(self.resource, 5, 2, 56, iso=True)
@@ -282,6 +282,7 @@ class AWSObjectStoreTestMixin(object):
         self.assertEqual(parts.is_iso, True)
 
 
+@patch('spdb.spatialdb.object.get_region', return_value='us-east-1')
 class TestAWSObjectStore(AWSObjectStoreTestMixin, unittest.TestCase):
 
     @classmethod
@@ -305,8 +306,10 @@ class TestAWSObjectStore(AWSObjectStoreTestMixin, unittest.TestCase):
 
         # Create AWS Resources needed for tests
         cls.setup_helper.start_mocking()
-        cls.setup_helper.create_index_table(cls.object_store_config["s3_index_table"], cls.setup_helper.DYNAMODB_SCHEMA)
-        cls.setup_helper.create_cuboid_bucket(cls.object_store_config["cuboid_bucket"])
+        with patch('spdb.spatialdb.test.setup.get_region') as fake_get_region:
+            fake_get_region.return_value = 'us-east-1'
+            cls.setup_helper.create_index_table(cls.object_store_config["s3_index_table"], cls.setup_helper.DYNAMODB_SCHEMA)
+            cls.setup_helper.create_cuboid_bucket(cls.object_store_config["cuboid_bucket"])
 
     @classmethod
     def tearDownClass(cls):

--- a/spatialdb/test/test_object_indices.py
+++ b/spatialdb/test/test_object_indices.py
@@ -26,7 +26,7 @@ from spdb.spatialdb.object import AWSObjectStore
 from spdb.spatialdb import SpatialDB
 from spdb.spatialdb.cube import Cube
 import unittest
-from unittest.mock import patch, DEFAULT
+from unittest.mock import patch, DEFAULT, ANY
 import random
 
 from bossutils import configuration
@@ -808,10 +808,6 @@ class ObjectIndicesTestMixin(object):
             self.resource, res, time_sample, morton)
         chan_key = self.obj_ind.generate_channel_id_key(self.resource, res, id)
         key_parts = AWSObjectStore.get_object_key_parts(obj_key)
-        lookup_key = AWSObjectStore.generate_lookup_key(
-            key_parts.collection_id, key_parts.experiment_id, 
-            key_parts.channel_id, key_parts.resolution)
-
 
         with patch.multiple(
             self.obj_ind, 
@@ -832,8 +828,8 @@ class ObjectIndicesTestMixin(object):
 
             mocks['write_cuboid'].assert_called_with(
                 max_capacity, str(morton), chan_key, last_partition_key, 
-                rev_id, lookup_key, version)
-            self.assertFalse(mocks['update_last_partition_key'].called)
+                rev_id, ANY, version)
+            mocks['update_last_partition_key'].assert_not_called()
 
     def test_write_id_index_new_id(self):
         """
@@ -852,10 +848,6 @@ class ObjectIndicesTestMixin(object):
             self.resource, res, time_sample, morton)
         chan_key = self.obj_ind.generate_channel_id_key(self.resource, res, id)
         key_parts = AWSObjectStore.get_object_key_parts(obj_key)
-        lookup_key = AWSObjectStore.generate_lookup_key(
-            key_parts.collection_id, key_parts.experiment_id, 
-            key_parts.channel_id, key_parts.resolution)
-
 
         with patch.multiple(
             self.obj_ind, 
@@ -877,8 +869,8 @@ class ObjectIndicesTestMixin(object):
 
             mocks['write_cuboid'].assert_called_with(
                 max_capacity, str(morton), chan_key, last_partition_key, 
-                rev_id, lookup_key, version)
-            self.assertFalse(mocks['update_last_partition_key'].called)
+                rev_id, ANY, version)
+            mocks['update_last_partition_key'].assert_not_called()
 
     def test_write_id_index_overflow(self):
         """
@@ -899,9 +891,6 @@ class ObjectIndicesTestMixin(object):
             self.resource, res, time_sample, morton)
         chan_key = self.obj_ind.generate_channel_id_key(self.resource, res, id)
         key_parts = AWSObjectStore.get_object_key_parts(obj_key)
-        lookup_key = AWSObjectStore.generate_lookup_key(
-            key_parts.collection_id, key_parts.experiment_id, 
-            key_parts.channel_id, key_parts.resolution)
 
         with patch.multiple(
             self.obj_ind, 
@@ -922,7 +911,7 @@ class ObjectIndicesTestMixin(object):
 
             mocks['write_cuboid'].assert_called_with(
                 max_capacity, str(morton), chan_key, last_partition_key, 
-                rev_id, lookup_key, version)
+                rev_id, ANY, version)
             mocks['update_last_partition_key'].assert_called_with(
                 chan_key, last_partition_key + 1,  version)
 

--- a/spatialdb/test/test_object_indices.py
+++ b/spatialdb/test/test_object_indices.py
@@ -563,8 +563,8 @@ class ObjectIndicesTestMixin(object):
         with patch.object(self.obj_ind, 'write_cuboid_dynamo') as fake_write_cuboid_dynamo:
 
             fake_write_cuboid_dynamo.return_value = {
-                'ResponseMetadata': { 'HTTPStatusCode': 200 },
-                'ConsumedCapacity': 105.0
+                'ResponseMetadata': {'HTTPStatusCode': 200},
+                'ConsumedCapacity': {'CapacityUnits': 105.0}
             }
 
             res = 0

--- a/spatialdb/test/test_spatialdb.py
+++ b/spatialdb/test/test_spatialdb.py
@@ -27,6 +27,7 @@ import numpy as np
 from spdb.spatialdb.test.setup import SetupTests
 
 
+@patch('spdb.spatialdb.object.get_region', autospec=True, return_value='us-east-1')
 class SpatialDBImageDataTestMixin(object):
 
     cuboid_size = CUBOIDSIZE[0]
@@ -73,7 +74,7 @@ class SpatialDBImageDataTestMixin(object):
 
         return keys
 
-    def test_resource_locked(self):
+    def test_resource_locked(self, fake_get_region):
         """Method to test if the resource is locked"""
         sp = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
 
@@ -87,7 +88,7 @@ class SpatialDBImageDataTestMixin(object):
         sp.cache_state.set_project_lock(self.resource.get_lookup_key(), False)
         assert not sp.resource_locked(self.resource.get_lookup_key())
 
-    def test_get_cubes_no_time_single(self):
+    def test_get_cubes_no_time_single(self, fake_get_region):
         """Test the get_cubes method - no time - single"""
         # Generate random data
         cube1 = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim])
@@ -103,7 +104,7 @@ class SpatialDBImageDataTestMixin(object):
 
         np.testing.assert_array_equal(cube1.data, cube2[0].data)
 
-    def test_get_cubes_no_time_multiple(self):
+    def test_get_cubes_no_time_multiple(self, fake_get_region):
         """Test the get_cubes method - no time - multiple cubes"""
         # Generate random data
 
@@ -130,7 +131,7 @@ class SpatialDBImageDataTestMixin(object):
         np.testing.assert_array_equal(cube2.data, cube_read[1].data)
         np.testing.assert_array_equal(cube3.data, cube_read[2].data)
 
-    def test_get_cubes_time_single(self):
+    def test_get_cubes_time_single(self, fake_get_region):
         """Test the get_cubes method - time - single"""
         # Generate random data
         cube1 = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim], [0, 2])
@@ -146,7 +147,7 @@ class SpatialDBImageDataTestMixin(object):
 
         np.testing.assert_array_equal(cube1.data, cube2[0].data)
 
-    def test_get_cubes_time_multiple(self):
+    def test_get_cubes_time_multiple(self, fake_get_region):
         """Test the get_cubes method - time - multiple"""
         # Generate random data
         cube1 = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim], [0, 4])
@@ -167,7 +168,7 @@ class SpatialDBImageDataTestMixin(object):
         np.testing.assert_array_equal(cube1.data, cube_read[0].data)
         np.testing.assert_array_equal(cube2.data, cube_read[1].data)
 
-    def test_cutout_no_time_single_aligned_zero(self):
+    def test_cutout_no_time_single_aligned_zero(self, fake_get_region):
         """Test the get_cubes method - no time - single"""
         db = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
 
@@ -175,7 +176,7 @@ class SpatialDBImageDataTestMixin(object):
 
         np.testing.assert_array_equal(np.sum(cube.data), 0)
 
-    def test_cutout_no_time_single_aligned_zero_no_cache(self):
+    def test_cutout_no_time_single_aligned_zero_no_cache(self, fake_get_region):
         """Test the get_cubes method - no time - single - bypass cache"""
         db = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
 
@@ -183,7 +184,7 @@ class SpatialDBImageDataTestMixin(object):
 
         np.testing.assert_array_equal(np.sum(cube.data), 0)
 
-    def test_cutout_no_time_single_aligned_hit(self):
+    def test_cutout_no_time_single_aligned_hit(self, fake_get_region):
         """Test the get_cubes method - no time - single"""
         # Generate random data
         cube1 = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim])
@@ -199,7 +200,7 @@ class SpatialDBImageDataTestMixin(object):
 
         np.testing.assert_array_equal(cube1.data, cube2.data)
 
-    def test_cutout_no_time_single_aligned_miss(self):
+    def test_cutout_no_time_single_aligned_miss(self, fake_get_region):
         """Test the get_cubes method - no time - single"""
         # Generate random data
         cube1 = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim])
@@ -215,7 +216,7 @@ class SpatialDBImageDataTestMixin(object):
 
         np.testing.assert_array_equal(cube1.data, cube2.data)
 
-    def test_write_cuboid_off_base_res(self):
+    def test_write_cuboid_off_base_res(self, fake_get_region):
         """Test writing a cuboid to not the base resolution"""
         # Generate random data
         cube1 = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim])
@@ -266,8 +267,10 @@ class TestSpatialDBImage8Data(SpatialDBImageDataTestMixin, unittest.TestCase):
 
         # Create AWS Resources needed for tests
         self.setup_helper.start_mocking()
-        self.setup_helper.create_index_table(self.object_store_config["s3_index_table"], self.setup_helper.DYNAMODB_SCHEMA)
-        self.setup_helper.create_cuboid_bucket(self.object_store_config["cuboid_bucket"])
+        with patch('spdb.spatialdb.test.setup.get_region') as fake_get_region:
+            fake_get_region.return_value = 'us-east-1'
+            self.setup_helper.create_index_table(self.object_store_config["s3_index_table"], self.setup_helper.DYNAMODB_SCHEMA)
+            self.setup_helper.create_cuboid_bucket(self.object_store_config["cuboid_bucket"])
 
     def tearDown(self):
         # Stop mocking
@@ -311,8 +314,10 @@ class TestSpatialDBImage16Data(SpatialDBImageDataTestMixin, unittest.TestCase):
 
         # Create AWS Resources needed for tests
         self.setup_helper.start_mocking()
-        self.setup_helper.create_index_table(self.object_store_config["s3_index_table"], self.setup_helper.DYNAMODB_SCHEMA)
-        self.setup_helper.create_cuboid_bucket(self.object_store_config["cuboid_bucket"])
+        with patch('spdb.spatialdb.test.setup.get_region') as fake_get_region:
+            fake_get_region.return_value = 'us-east-1'
+            self.setup_helper.create_index_table(self.object_store_config["s3_index_table"], self.setup_helper.DYNAMODB_SCHEMA)
+            self.setup_helper.create_cuboid_bucket(self.object_store_config["cuboid_bucket"])
 
     def tearDown(self):
         # Stop mocking

--- a/spatialdb/utils/add_lookup_keys_to_s3_index.py
+++ b/spatialdb/utils/add_lookup_keys_to_s3_index.py
@@ -1,0 +1,253 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#    http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from spdb.spatialdb import AWSObjectStore
+import argparse
+import botocore
+import boto3
+import random
+import time
+
+# Attribute names in S3 index table.
+LOOKUP_KEY = 'lookup-key'
+OBJ_KEY = 'object-key'
+VERSION_NODE = 'version-node'
+
+class LookupKeyWriter(object):
+    """
+    Adds lookup key to legacy items in the S3 index table.  The lookup key is
+    collection&experiment&channel&resolution.  A global secondary index (GSI)
+    will use the lookup key to allow finding all cuboids that belong to a
+    particular channel via a DynamoDB query.
+
+    An instance of this class may be used as one worker in a parallelized
+    scan of the S3 index table.  See the AWS documentation here:
+
+    https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan
+
+    Attributes:
+        dynamodb (DynamoDB.Client): boto3 interface to DynamoDB.
+        table (str): Name of S3 index table.
+        max_items (int): Max number of items to return with each call to DynamoDB.Client.scan().
+        worker_num (int): Zero-based worker number if parallelizing.
+        num_workers (int): Total number of workers.
+    """
+
+    def __init__(
+        self, table_name, region, max_items, worker_num=0, num_workers=1):
+        """
+        Constructor.
+
+        If parallelizing, supply worker_num and num_workers.  See the AWS
+        documentation for parallel scan here:
+
+        https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan
+
+        Args:
+            table_name (str): Name of Dynamo S3 index table to operate on.
+            region (str): AWS region table lives in.
+            max_items (int): Max number of items to return with each call to DynamoDB.Client.scan().
+            worker_num (optional[int]): Zero-based worker number if parallelizing.
+            num_workers (optional[int]): Total number of workers.
+        """
+        self.dynamodb = boto3.client('dynamodb', region_name=region)
+        self.table = table_name
+        self.max_items = max_items
+        self.worker_num = worker_num
+        self.num_workers = num_workers
+        if worker_num >= num_workers:
+            raise ValueError('worker_num must be less than num_workers')
+
+    def start(self):
+        """
+        Starts scan and update of S3 index table.
+        """
+        exclusive_start_key = None
+        done = False
+        count = 0
+        while not done:
+            resp = self.scan(exclusive_start_key)
+            if resp is None:
+                continue
+
+            if 'LastEvaluatedKey' not in resp or len(resp['LastEvaluatedKey']) == 0:
+                done = True
+            else:
+                exclusive_start_key = resp['LastEvaluatedKey']
+
+            print('Consumed read capacity: {}'.format(resp['ConsumedCapacity']))
+
+            for item in resp['Items']:
+                print(item)
+                self.add_lookup_key(item)
+
+            if exclusive_start_key is not None:
+                print('Continuing scan following {} - {}.'.format(
+                    exclusive_start_key[OBJ_KEY]['S'], 
+                    exclusive_start_key[VERSION_NODE]['N']))
+
+            count+=1
+
+            # Terminate early for testing.
+            #if count > 2:
+            #    done = True
+
+        print('Update complete.')
+
+    def scan(self, exclusive_start_key=None):
+        """
+        Invoke DynamoDB.Client.scan() and get up to self.max_items.
+
+        Will use exponential backoff and retry 4 times if throttled by Dynamo.
+
+        Args:
+            exclusive_start_key (dict): If defined, start scan from this point in the table.
+
+        Returns:
+            (dict|None): Response dictionary from DynamoDB.Client.scan() or None if throttled repeatedly.
+        """
+        scan_args = {
+            'TableName': self.table,
+            'Limit': self.max_items,
+            'ProjectionExpression': '#objkey,#vernode,#lookupkey',
+            'FilterExpression':'attribute_not_exists(#lookupkey)',
+            'ExpressionAttributeNames': {
+                '#lookupkey': LOOKUP_KEY,
+                '#objkey': OBJ_KEY,
+                '#vernode': VERSION_NODE
+            },
+            'ConsistentRead': True,
+            'ReturnConsumedCapacity': 'TOTAL'
+        }
+
+        if exclusive_start_key is not None:
+            scan_args['ExclusiveStartKey'] = exclusive_start_key
+
+        if self.num_workers > 1:
+            scan_args['Segment'] = self.worker_num
+            scan_args['TotalSegments'] = self.num_workers
+
+        for backoff in range(0, 6):
+            try:
+                resp = self.dynamodb.scan(**scan_args)
+                return resp
+            except botocore.exceptions.ClientError as ex:
+                if ex.response['Error']['Code'] == 'ProvisionedThroughputExceededException':
+                    print('Throttled during scan . . .')
+                    time.sleep(((2 ** backoff) + (random.randint(0, 1000) / 1000.0))/10.0)
+                else:
+                    raise
+
+        return None
+
+    def add_lookup_key(self, item):
+        """
+        Using the given item from the S3 index table, extract the lookup key
+        from the object key and write it back to the item as a new attribute.
+
+        If throttled, will use exponential backoff and retry 5 times.
+
+        Args:
+            item (dict): An item from the response dictionary returned by DynamoDB.Client.scan().
+        """
+        if OBJ_KEY not in item or 'S' not in item[OBJ_KEY]:
+            return
+
+        if VERSION_NODE not in item:
+            return
+
+        parts = AWSObjectStore.get_object_key_parts(item[OBJ_KEY]['S'])
+        lookup_key = AWSObjectStore.generate_lookup_key(
+            parts.collection_id, parts.experiment_id, parts.channel_id,
+            parts.resolution)
+
+        NUM_RETRIES = 5
+        for backoff in range(0, NUM_RETRIES + 1):
+            try:
+                self.dynamodb.update_item(
+                    TableName=self.table,
+                    Key={OBJ_KEY: item[OBJ_KEY], VERSION_NODE: item[VERSION_NODE]},
+                    ExpressionAttributeNames = {'#lookupkey': LOOKUP_KEY},
+                    ExpressionAttributeValues = {':lookupkey': {'S': lookup_key}},
+                    UpdateExpression='set #lookupkey = :lookupkey'
+                )
+                return
+            except botocore.exceptions.ClientError as ex:
+                if ex.response['Error']['Code'] == 'ProvisionedThroughputExceededException':
+                    print('Throttled during update of item: {} - {}'.format(
+                        item[OBJ_KEY]['S'], item[VERSION_NODE]['N']))
+                    time.sleep(((2 ** backoff) + (random.randint(0, 1000) / 1000.0))/10.0)
+                else:
+                    print('Failed updating item: {} - {}'.format(
+                        item[OBJ_KEY]['S'], item[VERSION_NODE]['N']))
+                    raise
+            except:
+                print('Failed updating item: {} - {}'.format(
+                    item[OBJ_KEY]['S'], item[VERSION_NODE]['N']))
+                raise
+
+
+        print('Failed and giving up after {} retries trying to update item: {} - {}'
+            .format(NUM_RETRIES, item[OBJ_KEY]['S'], item[VERSION_NODE]['N']))
+
+
+def script_args():
+    """
+    Parse command line arguments.
+
+    Returns:
+        (argparse.Namespace): Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description='Script to update legacy items in the S3 index table with a lookup key.'
+    )
+    parser.add_argument(
+        '--table-name', '-t',
+        required=True,
+        help='Name of S3 index table such as s3index.production.boss'
+    )
+    parser.add_argument(
+        '--region', '-r',
+        default='us-east-1',
+        help='AWS region of table, default: us-east-1'
+    )
+    parser.add_argument(
+        '--max-items', '-m',
+        type=int,
+        required=True,
+        help='Max items to retrieve from DynamoDB in one scan operation'
+    )
+    parser.add_argument(
+        '--worker_num',
+        type=int,
+        default=0,
+        help='Zero-based worker id for this process when parallelizing.  Must be < --num_workers'
+    )
+    parser.add_argument(
+        '--num_workers',
+        type=int,
+        default=1,
+        help='Total number of parallel processes that will be used'
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = script_args()
+    writer = LookupKeyWriter(
+        args.table_name, args.region, args.max_items,
+        args.worker_num, args.num_workers)
+    writer.start()
+


### PR DESCRIPTION
Initial PR to move object indexing into integration.

Please take a close look at `spatialdb/utils/add_lookup_keys_to_s3_index.py`. This script will update the production Dynamo s3index so that the lookup-key attribute is populated.

Accompanying PRs:
* https://github.com/jhuapl-boss/boss-manage/pull/8
* https://github.com/jhuapl-boss/boss-tools/pull/4
* https://github.com/jhuapl-boss/boss/pull/10
