### PR TITLE
Fix time series bug. - to integration

### DIFF
--- a/spatialdb/test/test_cube.py
+++ b/spatialdb/test/test_cube.py
@@ -371,6 +371,34 @@ class TestImageCube8(unittest.TestCase):
         assert c.is_time_series is True
         assert c2.is_time_series is True
 
+    def test_blosc_missing_time_step(self):
+        """Test case when one of the cuboids at a time step is missing.  This
+        happens when trying to load from the cache.  Only keys in the cache
+        are passed to from_blosc().
+        """
+        EXTENTS = [10, 20, 5]
+        cube_t0_1 = ImageCube8(EXTENTS, [0, 2])
+        cube_t3 = ImageCube8(EXTENTS)
+        exp_cube = ImageCube8(EXTENTS, [0, 4])
+        exp_cube.zeros()
+        exp_cube.overwrite(cube_t0_1.data, [0, 2])
+        exp_cube.overwrite(cube_t3.data, [3, 4])
+
+        cube_bytes_t0 = cube_t0_1.to_blosc_by_time_index(0)
+        cube_bytes_t1 = cube_t0_1.to_blosc_by_time_index(1)
+        cube_bytes_t3 = cube_t3.to_blosc_by_time_index(0)
+        cube_list = (cube_bytes_t0, cube_bytes_t1, cube_bytes_t3)
+
+        actual_cube = ImageCube8(EXTENTS, [0, 4])
+
+        missing_time_step = [2]
+
+        # Method under test.
+        actual_cube.from_blosc(cube_list, [0, 4], missing_time_step)
+
+        np.testing.assert_array_equal(exp_cube.data, actual_cube.data)
+        assert actual_cube.is_time_series is True
+
     def test_factory_no_time(self):
         """Test the Cube factory in Cube"""
 
@@ -761,6 +789,34 @@ class TestImageCube16(unittest.TestCase):
         assert c.time_range == c2.time_range
         assert c.is_time_series is True
         assert c2.is_time_series is True
+
+    def test_blosc_missing_time_step(self):
+        """Test case when one of the cuboids at a time step is missing.  This
+        happens when trying to load from the cache.  Only keys in the cache
+        are passed to from_blosc().
+        """
+        EXTENTS = [10, 20, 5]
+        cube_t0_1 = ImageCube16(EXTENTS, [0, 2])
+        cube_t3 = ImageCube16(EXTENTS)
+        exp_cube = ImageCube16(EXTENTS, [0, 4])
+        exp_cube.zeros()
+        exp_cube.overwrite(cube_t0_1.data, [0, 2])
+        exp_cube.overwrite(cube_t3.data, [3, 4])
+
+        cube_bytes_t0 = cube_t0_1.to_blosc_by_time_index(0)
+        cube_bytes_t1 = cube_t0_1.to_blosc_by_time_index(1)
+        cube_bytes_t3 = cube_t3.to_blosc_by_time_index(0)
+        cube_list = (cube_bytes_t0, cube_bytes_t1, cube_bytes_t3)
+
+        actual_cube = ImageCube16(EXTENTS, [0, 4])
+
+        missing_time_step = [2]
+
+        # Method under test.
+        actual_cube.from_blosc(cube_list, [0, 4], missing_time_step)
+
+        np.testing.assert_array_equal(exp_cube.data, actual_cube.data)
+        assert actual_cube.is_time_series is True
 
     def test_overwrite_dtype_mismatch(self):
         c_base = ImageCube16([10, 10, 10])

--- a/spatialdb/test/test_spatialdb.py
+++ b/spatialdb/test/test_spatialdb.py
@@ -26,7 +26,13 @@ import numpy as np
 
 from spdb.spatialdb.test.setup import SetupTests
 
+import spdb.spatialdb.object
 
+
+def get_region_east_1():
+    return 'us-east-1'
+
+@patch('spdb.spatialdb.object.get_region', get_region_east_1)
 class SpatialDBImageDataTestMixin(object):
 
     cuboid_size = CUBOIDSIZE[0]
@@ -167,6 +173,42 @@ class SpatialDBImageDataTestMixin(object):
         np.testing.assert_array_equal(cube1.data, cube_read[0].data)
         np.testing.assert_array_equal(cube2.data, cube_read[1].data)
 
+    def test_get_cubes_missing_time_step(self):
+        """Test get_cubes() when not supplying keys for all time steps in a 
+        time range.
+        """
+        EXTENTS = [self.x_dim, self.y_dim, self.z_dim]
+        FIRST_T_RNG = (0, 4)
+        cube1 = Cube.create_cube(self.resource, EXTENTS, FIRST_T_RNG)
+        cube1.random()
+        cube1.morton_id = 70
+
+        # Note, no data for time steps 4 and 5 provided.
+
+        SECOND_T_RNG = (6, 9)
+        cube2 = Cube.create_cube(self.resource, EXTENTS, SECOND_T_RNG)
+        cube2.random()
+        cube2.morton_id = 70
+
+        TOTAL_T_RNG = (0, 9)
+        exp_cube = Cube.create_cube(self.resource, EXTENTS, TOTAL_T_RNG)
+        exp_cube.zeros()
+        exp_cube.morton_id = 70
+        exp_cube.overwrite(cube1.data, FIRST_T_RNG)
+        exp_cube.overwrite(cube2.data, SECOND_T_RNG)
+            
+
+        db = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
+
+        # populate dummy data
+        keys = self.write_test_cube(db, self.resource, 0, cube1, cache=True, s3=False)
+        keys.extend(self.write_test_cube(db, self.resource, 0, cube2, cache=True, s3=False))
+
+        # Method under test.
+        cube_read = db.get_cubes(self.resource, keys)
+
+        np.testing.assert_array_equal(exp_cube.data, cube_read[0].data)
+
     def test_cutout_no_time_single_aligned_zero(self):
         """Test the get_cubes method - no time - single"""
         db = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
@@ -228,14 +270,34 @@ class SpatialDBImageDataTestMixin(object):
         with self.assertRaises(SpdbError):
             db.write_cuboid(self.resource, (0, 0, 0), 5, cube1.data, time_sample_start=0)
 
+    def test_mark_missing_time_steps_none(self):
+        samples = [0, 1, 2, 3, 4, 5, 6]
+
+        db = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
+
+        actual = db.mark_missing_time_steps(samples, 2, 5)
+
+        self.assertEqual([], actual)
+
+    def test_mark_missing_time_steps(self):
+        samples = [0, 1, 3, 5, 6, 7]
+
+        db = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
+
+        actual = db.mark_missing_time_steps(samples, 1, 4)
+
+        self.assertEqual([2, 4], actual)
+
 
 @patch('redis.StrictRedis', mock_strict_redis_client)
 class TestSpatialDBImage8Data(SpatialDBImageDataTestMixin, unittest.TestCase):
 
+    @patch('spdb.spatialdb.test.setup.get_region')
     @patch('redis.StrictRedis', mock_strict_redis_client)
-    def setUp(self):
+    def setUp(self, fake_get_region):
         """ Set everything up for testing """
         # setup resources
+        fake_get_region.return_value = 'us-east-1'
         self.setup_helper = SetupTests()
         self.setup_helper.mock = True
 
@@ -277,10 +339,13 @@ class TestSpatialDBImage8Data(SpatialDBImageDataTestMixin, unittest.TestCase):
 @patch('redis.StrictRedis', mock_strict_redis_client)
 class TestSpatialDBImage16Data(SpatialDBImageDataTestMixin, unittest.TestCase):
 
+
+    @patch('spdb.spatialdb.test.setup.get_region')
     @patch('redis.StrictRedis', mock_strict_redis_client)
-    def setUp(self):
+    def setUp(self, fake_get_region):
         """ Set everything up for testing """
         # setup resources
+        fake_get_region.return_value = 'us-east-1'
         self.setup_helper = SetupTests()
         self.setup_helper.mock = True
 


### PR DESCRIPTION
If a cuboid for a particular time step is not in S3, Cube.from_blosc()
would fail to decompress the existing cuboid time steps. Now marking
missing time steps and putting in zeros for those missing cuboid time
steps.