### PR TITLE
support for larger data downsampling

### DIFF
--- a/c_lib/ndtype.py
+++ b/c_lib/ndtype.py
@@ -18,16 +18,7 @@ import numpy as np
 # Cuboid Size
 # TODO: Look into moving this into a data model table and set based on voxel size
 # non-isotropic slices should be 512,512,16. As you downsample move to 64,64,64 past isotropic
-CUBOIDSIZE = [[512, 512, 16],
-              [512, 512, 16],
-              [512, 512, 16],
-              [512, 512, 16],
-              [512, 512, 16],
-              [512, 512, 16],
-              [512, 512, 16],
-              [512, 512, 16],
-              [512, 512, 16],
-              [512, 512, 16]]
+CUBOIDSIZE = [[512, 512, 16]] * 13
 
 # SuperCube Size
 SUPERCUBESIZE = [1, 1, 1]
@@ -52,5 +43,3 @@ SUPERCUBESIZE = [1, 1, 1]
 PROPAGATED = 2
 UNDER_PROPAGATION = 1
 NOT_PROPAGATED = 0
-
-


### PR DESCRIPTION
We were limited to 9 levels of downsampling, which was too small for some larger datasets to fully fit into one cube at the highest level of downsampling.  This change increases the limit from 262,144 pixels in the longest dimension to 2,097,152.