### PR TITLE
delete-update

### DIFF
--- a/spatialdb/dynamo/s3_index_table.json
+++ b/spatialdb/dynamo/s3_index_table.json
@@ -7,6 +7,18 @@
         {
             "AttributeName": "version-node",
             "AttributeType": "N"
+        },
+        {
+            "AttributeName": "ingest-job-hash",
+            "AttributeType": "S"
+        },
+        {
+            "AttributeName": "ingest-job-range",
+            "AttributeType": "S"
+        },
+        {
+            "AttributeName": "ingest-id-hash",
+            "AttributeType": "S"
         }
     ],
     "KeySchema": [
@@ -17,6 +29,44 @@
         {
             "AttributeName": "version-node",
             "KeyType": "RANGE"
+        }
+    ],
+    "GlobalSecondaryIndexes": [
+        {
+            "IndexName": "ingest-job-index",
+            "KeySchema": [
+                {
+                    "AttributeName": "ingest-job-hash",
+                    "KeyType": "HASH"
+                },
+                {
+                    "AttributeName": "ingest-job-range",
+                    "KeyType": "RANGE"
+                }
+            ],
+            "Projection": {
+                "ProjectionType": "KEYS_ONLY"
+            },
+            "ProvisionedThroughput": {
+                "ReadCapacityUnits": 15,
+                "WriteCapacityUnits": 15
+            }
+        },
+        {
+            "IndexName": "ingest-id-index",
+            "KeySchema": [
+                {
+                    "AttributeName": "ingest-id-hash",
+                    "KeyType": "HASH"
+                }
+            ],
+            "Projection": {
+                "ProjectionType": "KEYS_ONLY"
+            },
+            "ProvisionedThroughput": {
+                "ReadCapacityUnits": 15,
+                "WriteCapacityUnits": 15
+            }
         }
     ],
     "ProvisionedThroughput": {

--- a/spatialdb/object.py
+++ b/spatialdb/object.py
@@ -21,12 +21,19 @@ import numpy as np
 from .error import SpdbError, ErrorCodes
 from .object_indices import ObjectIndices
 from .region import Region
+from random import randint
 from spdb.c_lib.ndlib import XYZMorton
 
 from bossutils.aws import get_region
 
 import boto3
 
+"""
+Max integer suffix appended to ingest-id attribute in the DynamoDB s3 index
+table.  This attribute is the key of the ingest-id-index.  This GSI is used
+during deletion of a channel.
+"""
+INGEST_ID_MAX_N = 100
 
 class ObjectStore(metaclass=ABCMeta):
     def __init__(self, object_store_conf):
@@ -266,6 +273,26 @@ class AWSObjectStore(ObjectStore):
         return KeyParts(hash=hash, collection_id=collection_id, experiment_id=experiment_id, channel_id=channel_id,
                         resolution=resolution, time_sample=time_sample, morton_id=morton_id, is_iso=is_iso)
 
+    @staticmethod
+    def get_ingest_id_hash(coll_id, exp_id, chan_id, res, job_id, i):
+        """
+        Generate the key used to represent a particular ingest job.  This should
+        match the ingest-id-hash attribute in the s3 index.
+
+        Args:
+            coll_id (int): Collection id.
+            exp_id (int): Experiment id.
+            chan_id (int): Channel id.
+            res (int): Resolution.
+            job_id (int): Ingest job id.
+            i (int): Suffix used to prevent hot partitions during ingest (<= INGEST_ID_MAX_N).
+
+        Returns:
+            (str):
+        """
+        key = '{}&{}&{}&{}&{}#{}'.format(coll_id, exp_id, chan_id, res, job_id, i) 
+        return key
+
     def generate_object_key(self, resource, resolution, time_sample, morton_id, iso=False):
         """Generate Key for an object stored in the S3 cuboid bucket
 
@@ -357,18 +384,17 @@ class AWSObjectStore(ObjectStore):
         # Get lookup key and resolution from object key
         parts = self.get_object_key_parts(object_key)
 
-        # range key is exp&ch&res&task
-        ingest_job_range = "{}&{}&{}&{}".format(parts.experiment_id, parts.channel_id, parts.resolution, ingest_job)
-
         try:
             dynamodb.put_item(
                 TableName=self.config['s3_index_table'],
                 Item={'object-key': {'S': object_key},
                       'version-node': {'N': "{}".format(version)},
-                      'ingest-job-hash': {'S': "{}".format(parts.collection_id)},
-                      'ingest-job-range': {'S': ingest_job_range}},
+                      'ingest-id-hash': {'S': AWSObjectStore.get_ingest_id_hash(
+                          parts.collection_id, parts.experiment_id,
+                          parts.channel_id, parts.resolution,
+                          ingest_job, randint(0, INGEST_ID_MAX_N))}},
                 ReturnConsumedCapacity='NONE',
-                ReturnItemCollectionMetrics='NONE',
+                ReturnItemCollectionMetrics='NONE'
             )
         except:
             raise SpdbError("Error adding object-key to index.",


### PR DESCRIPTION
Update delete process to work with new GSI used for the DynamoDB s3Index table.

New GSI for the Dynamo S3 index that tracks ingests by collection,
experiment, and channel ids as well as resolution and job id.  The GSI
also has an int appended to it to avoid hot partitions during ingest.

The old GSI is restored but no cuboids from new ingests will be tracked
by it.  The old GSI will be used when old channels are deleted.

Related PRs:
https://github.com/jhuapl-boss/boss-tools/pull/15
https://github.com/jhuapl-boss/boss/pull/17
