### PR TITLE
Raw no cache feature

### DIFF
--- a/spatialdb/spatialdb.py
+++ b/spatialdb/spatialdb.py
@@ -340,7 +340,7 @@ class SpatialDB:
         return result_tuple(effcorner, effdim, None, None)
 
     # Main Interface Methods
-    def cutout(self, resource, corner, extent, resolution, time_sample_range=None, filter_ids=None, iso=False, no_cache=False):
+    def cutout(self, resource, corner, extent, resolution, time_sample_range=None, filter_ids=None, iso=False, no_cache=False, raw=False):
         """Extract a cube of arbitrary size. Need not be aligned to cuboid boundaries.
 
         corner represents the location of the cutout and extent the size.  As an example in 1D, if asking for
@@ -357,7 +357,8 @@ class SpatialDB:
             time_sample_range (list((int)):  a range of time samples to get [start, stop). Default is [0,1) if omitted
             filter_ids (optional[list]): Defaults to None. Otherwise, is a list of uint64 ids to filter cutout by.
             iso (bool): Flag indicating if you want to get to the "isotropic" version of a cuboid, if available
-            no_cache (bool): True to read directly from S3 and bypass the cache.
+            no_cache (bool): True to read directly from S3 and bypass the cache while still checking for dirty keys. 
+            raw (bool): True to read directly from S3 and bypass cache and checking for dirty keys. 
 
         Returns:
             cube.Cube: The cutout data stored in a Cube instance
@@ -459,19 +460,16 @@ class SpatialDB:
         # xyz offset stored for later use
         lowxyz = ndlib.MortonXYZ(list_of_idxs[0])
 
-        if no_cache:
-            # TODO SH As 10/3/18 the boss get_cutout is not scaling. This is a quick hack to get us back up and running at scale.
-            #      Ideally we want to have two options:
-            #      1) no-cache which would skip the cache for reads but would still check for dirty keys
-            #      2) We will also add a "raw" option which would skip both.
-            #      Since the system is not scaling now we are switching the only option "no-cache" to avoid checking
-            #      for writes as well.  This means it would be possible for someone to retreive stale data.
-            #
+        # If the user specifies the raw flag, then the system will bypass checking for dirty keys. 
+        # This option is only recommended for large quickly scaling ingest jobs. 
+        if raw:
             blog.debug("Bypassing write check of dirty keys")
             missing_key_idx = []
             cached_key_idx = []
             all_keys = self.kvio.generate_cached_cuboid_keys(resource, cutout_resolution,
                                                              list(range(*time_sample_range)), list_of_idxs, iso=iso)
+
+        # If the user specified either no_cache or both flags are negative. Then the system will check for dirty keys. 
         else:
             # Get index of missing keys for cuboids to read
             missing_key_idx, cached_key_idx, all_keys = self.kvio.get_missing_read_cache_keys(resource,
@@ -508,8 +506,9 @@ class SpatialDB:
         s3_cuboids = []
         zero_cuboids = []
 
-        if no_cache:
-            # If not using the cache, then consider all keys are missing.
+        # If either no_cache or raw flags are True then bypass the cache and load all cuboids directly from S3
+        if no_cache or raw:
+            # If not using the cache or raw flags, then consider all keys are missing.
             blog.debug("Bypassing cache; loading all cuboids directly from S3")
             missing_key_idx = [i for i in range(len(all_keys))]
 
@@ -519,7 +518,7 @@ class SpatialDB:
             s3_key_idx, zero_key_idx = self.objectio.cuboids_exist(all_keys, missing_key_idx)
 
             if len(s3_key_idx) > 0:
-                if no_cache:
+                if no_cache or raw:
                     temp_keys = self.objectio.cached_cuboid_to_object_keys(itemgetter(*s3_key_idx)(all_keys))
 
                     # Get objects
@@ -552,7 +551,7 @@ class SpatialDB:
                         self.kvio.put_cubes(itemgetter(*s3_key_idx)(all_keys), temp_cubes)
 
             if len(zero_key_idx) > 0:
-                if not no_cache:
+                if not no_cache or raw:
                     blog.debug("Data missing in cache, but not in S3")
                 else:
                     blog.debug("No data for some keys, making cuboids with zeros")
@@ -568,7 +567,7 @@ class SpatialDB:
                     zero_cuboids.append(temp_cube)
 
         # Get cubes from the cache database (either already there or freshly paged in)
-        if not no_cache:
+        if not no_cache or raw:
             # TODO: Optimize access to cache data and checking for dirty cubes
             if len(s3_key_idx) > 0:
                 blog.debug("Get cubes from cache that were paged in from S3")

--- a/spatialdb/spatialdb.py
+++ b/spatialdb/spatialdb.py
@@ -465,6 +465,7 @@ class SpatialDB:
         # If the user specifies the access_mode to be raw, then the system will bypass checking for dirty keys. 
         # This option is only recommended for large quickly scaling ingest jobs. 
         if access_mode == "raw":
+            blog.info("In access_mode {}, bypassing write of dirty keys".format(access_mode))
             blog.debug("Bypassing write check of dirty keys")
             missing_key_idx = []
             cached_key_idx = []
@@ -474,6 +475,7 @@ class SpatialDB:
         # If the user specified either no_cache or cache as the access_mode. Then the system will check for dirty keys. 
         else:
             # Get index of missing keys for cuboids to read
+            blog.info("In access_mode {}, checking for dirty keys".format(access_mode))
             missing_key_idx, cached_key_idx, all_keys = self.kvio.get_missing_read_cache_keys(resource,
                                                                                               cutout_resolution,
                                                                                               time_sample_range,
@@ -510,6 +512,7 @@ class SpatialDB:
 
         # If access_mode is either raw or no_cache, then bypass the cache and load all cuboids directly from S3
         if access_mode == "no_cache" or access_mode == "raw":
+            blog.info("In access_mode {}, bypassing cache".format(access_mode))
             # If not using the cache or raw flags, then consider all keys are missing.
             blog.debug("Bypassing cache; loading all cuboids directly from S3")
             missing_key_idx = [i for i in range(len(all_keys))]
@@ -570,6 +573,7 @@ class SpatialDB:
 
         # Get cubes from the cache database (either already there or freshly paged in)
         if  access_mode =="cache":
+            blog.info("In access_mode {}, using cache".format(access_mode))
             # TODO: Optimize access to cache data and checking for dirty cubes
             if len(s3_key_idx) > 0:
                 blog.debug("Get cubes from cache that were paged in from S3")

--- a/spatialdb/spatialdb.py
+++ b/spatialdb/spatialdb.py
@@ -357,7 +357,7 @@ class SpatialDB:
             time_sample_range (list((int)):  a range of time samples to get [start, stop). Default is [0,1) if omitted
             filter_ids (optional[list]): Defaults to None. Otherwise, is a list of uint64 ids to filter cutout by.
             iso (bool): Flag indicating if you want to get to the "isotropic" version of a cuboid, if available
-            access_mode (string): Indicates one of three possible modes.
+            access_mode (str): Indicates one of three possible modes.
                 cache = Will use cache and check for dirty keys
                 no_cache = Will skip checking the cache but check for dirty keys
                 raw = Will skip checking the cache and dirty keys
@@ -465,8 +465,7 @@ class SpatialDB:
         # If the user specifies the access_mode to be raw, then the system will bypass checking for dirty keys. 
         # This option is only recommended for large quickly scaling ingest jobs. 
         if access_mode == "raw":
-            blog.info("In access_mode {}, bypassing write of dirty keys".format(access_mode))
-            blog.debug("Bypassing write check of dirty keys")
+            blog.info("In access_mode {}, bypassing write check of dirty keys".format(access_mode))
             missing_key_idx = []
             cached_key_idx = []
             all_keys = self.kvio.generate_cached_cuboid_keys(resource, cutout_resolution,
@@ -514,7 +513,6 @@ class SpatialDB:
         if access_mode == "no_cache" or access_mode == "raw":
             blog.info("In access_mode {}, bypassing cache".format(access_mode))
             # If not using the cache or raw flags, then consider all keys are missing.
-            blog.debug("Bypassing cache; loading all cuboids directly from S3")
             missing_key_idx = [i for i in range(len(all_keys))]
 
         if len(missing_key_idx) > 0:

--- a/spatialdb/spatialdb.py
+++ b/spatialdb/spatialdb.py
@@ -554,7 +554,7 @@ class SpatialDB:
                         self.kvio.put_cubes(itemgetter(*s3_key_idx)(all_keys), temp_cubes)
 
             if len(zero_key_idx) > 0:
-                if  access_mode == "no_cache" or access_mode == "raw":
+                if  access_mode == "cache":
                     blog.debug("Data missing in cache, but not in S3")
                 else:
                     blog.debug("No data for some keys, making cuboids with zeros")

--- a/spatialdb/spatialdb.py
+++ b/spatialdb/spatialdb.py
@@ -625,7 +625,8 @@ class SpatialDB:
 
                     # Sleep a bit so you don't kill the DB
                     time.sleep(0.05)
-
+        if access_mode != "cache" and access_mode != "no_cache" and access_mode != "raw":
+            raise SpdbError('The access_mode "{}" specified is not valid'.format(access_mode), ErrorCodes.SPDB_ERROR)
         #
         # At this point, have all cuboids whether or not the cache was used.
         #

--- a/spatialdb/spatialdb.py
+++ b/spatialdb/spatialdb.py
@@ -369,6 +369,9 @@ class SpatialDB:
         boss_logger = BossLogger()
         boss_logger.setLevel("info")
         blog = boss_logger.logger
+        if no_cache and raw:
+            blog.debug("Both no_cache and raw options were set to True")
+            raise SpdbError("Both raw and no_cache cannot be True. Only set no_cache OR raw to True. ")
 
         if not time_sample_range:
             # If not time sample list defined, used default of 0

--- a/spatialdb/test/test_spatialdb.py
+++ b/spatialdb/test/test_spatialdb.py
@@ -175,13 +175,36 @@ class SpatialDBImageDataTestMixin(object):
 
         np.testing.assert_array_equal(np.sum(cube.data), 0)
 
-    def test_cutout_no_time_single_aligned_zero_no_cache(self):
+    def test_cutout_no_time_single_aligned_zero_access_mode_no_cache(self):
         """Test the get_cubes method - no time - single - bypass cache"""
         db = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
 
-        cube = db.cutout(self.resource, (7, 88, 243), (self.x_dim, self.y_dim, self.z_dim), 0, no_cache=True)
+        cube = db.cutout(self.resource, (7, 88, 243), (self.x_dim, self.y_dim, self.z_dim), 0, access_mode="no_cache")
 
         np.testing.assert_array_equal(np.sum(cube.data), 0)
+
+    def test_cutout_no_time_single_aligned_zero_access_mode_raw(self):
+        """Test the get_cubes method - no time - single - bypass cache and bypass dirty key check"""
+        db = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
+
+        cube = db.cutout(self.resource, (7, 88, 243), (self.x_dim, self.y_dim, self.z_dim), 0, access_mode="raw")
+
+        np.testing.assert_array_equal(np.sum(cube.data), 0)
+
+    def test_cutout_no_time_single_aligned_zero_access_mode_cache(self):
+        """Test the get_cubes method - no time - single - DO NOT bypass cache"""
+        db = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
+
+        cube = db.cutout(self.resource, (7, 88, 243), (self.x_dim, self.y_dim, self.z_dim), 0, access_mode="cache")
+
+        np.testing.assert_array_equal(np.sum(cube.data), 0)
+
+    def test_cutout_no_time_single_aligned_zero_access_mode_invalid(self):
+        """Test the get_cubes method - no time - single - Raise error due to invalid access_mode"""
+        db = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
+
+        with self.assertRaises(SpdbError):
+            db.cutout(self.resource, (7, 88, 243), (self.x_dim, self.y_dim, self.z_dim), 0, access_mode="wrong")
 
     def test_cutout_no_time_single_aligned_hit(self):
         """Test the get_cubes method - no time - single"""


### PR DESCRIPTION
This update allows the boss spatial database to operate in three different `access-modes` in order to bypass system scaling limitations. 

- `access_mode = cache` Utilizes the cache and checks for dirty keys
- `access_mode = no_cache` Does not check the cache but _does_ check for dirty keys
- `access_mode = raw` Does not check the cache and DOES NOT check for dirty keys. 

NOTE: Changes in the boss repository will handle the previous use of the `no_cache` parameter in order to allow backwards compatibility. 

**TESTS:**
This update was tested in the following manner:
1. AMIs were rebuilt to include the changes to the boss and spdb `boss-manage` submodules. 
2. Development stacks were built using the afore mentioned AMIs
3. The changes to the ingest-client repo were tested by ingest test data into the development boss using the intern plugin
4. The new version of `intern` was then utilized to check that the requests were made correctly for both large and small cutouts using both the previous `no_cache` option and the new `access_mode `option. The script can be found here: https://github.com/aplmicrons/user-scratch/blob/master/rodrilm2/intern/testAccessMode.py
5. Checked scalyr logs (both access.log and boss.log) to ensure that both the server and the client were performing as expected. 

PLEASE CHECK OTHER PR's related to this one:
jhuapl-boss/boss#21
jhuapl-boss/intern#30
jhuapl-boss/ingest-client#17