### PR TITLE
Change logic to allow for res uploads of base_resolution and base_res+1

### DIFF
--- a/spatialdb/spatialdb.py
+++ b/spatialdb/spatialdb.py
@@ -725,11 +725,12 @@ class SpatialDB:
                             'The requested resource is locked due to excessive write errors. Contact support.',
                             ErrorCodes.RESOURCE_LOCKED)
 
-        # Check to make sure the user is writing data at the BASE RESOLUTION
+        # TODO LR: This is temporary logic that will be removed after finalizing the current large data ingest. 
+        # Check to make sure the user is writing data at the BASE RESOLUTION or BASE RESOLUTION + 1
         channel = resource.get_channel()
-        if channel.base_resolution != resolution:
+        if channel.base_resolution != resolution and resolution != channel.base_resolution+1:
             raise SpdbError('Resolution Mismatch',
-                            "You can only write data to a channel's base resolution. Base Resolution: {}, Request Resolution: {}".format(channel.base_resolution, resolution),
+                            "You can only write data to a channel's base resolution or one resolution above it. Base Resolution: {}, Request Resolution: {}".format(channel.base_resolution, resolution),
                             ErrorCodes.RESOLUTION_MISMATCH)
 
         # Check if time-series


### PR DESCRIPTION
Simple logic change to allow for resolution uploads +1 base_resolution.

base_resoltuion is typically 0 and this holds true for current user ingesting data so the resolution allowed will be 1. 

This is meant to allow the script found here, to work:
https://github.com/aplmicrons/user-scratch/blob/master/rodrilm2/tests/allenUpRes.py

_Needs testing on integration stack_