### PR TITLE
Pinned blosc to 1.5.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
 Pillow>=4.1.1
 redis>=2.10.5
 mockredispy>=2.9.3
-blosc>=1.2.8
+
+# blosc 1.7.0 fails intermittently in the lambda environment.  Pinning at
+# 1.5.0 for now.
+blosc==1.5.0
 nose2
 numpy>=1.11.1
 moto


### PR DESCRIPTION
Currently, blosc 1.7.0 fails intermittentanly in the lambda environment.
1.5.0 does not exhibit this behavior.  The flush lambda exits abnormally
w/o an error message sometimes when running blosc.compress().