### PR TITLE
redis module 3.0 no longer accepts booleans, changing them to strings

### DIFF
--- a/spatialdb/state.py
+++ b/spatialdb/state.py
@@ -180,7 +180,7 @@ class CacheStateDB(object):
         """
         key = "WRITE-LOCK&{}".format(lookup_key)
         if locked:
-            self.status_client.set(key, True)
+            self.status_client.set(key, 'True')
         else:
             self.status_client.delete(key)
 


### PR DESCRIPTION
From: https://github.com/andymccurdy/redis-py#upgrading-from-redis-py-2x-to-30
Encoding of User Input
redis-py 3.0 only accepts user data as bytes, strings or numbers (ints, longs and floats). Attempting to specify a key or a value as any other type will raise a DataError exception.

redis-py 2.X attempted to coerce any type of input into a string. While occasionally convenient, this caused all sorts of hidden errors when users passed boolean values (which were coerced to 'True' or 'False'), a None value (which was coerced to 'None') or other values, such as user defined types.

All 2.X users should make sure that the keys and values they pass into redis-py are either bytes, strings or numbers.

this caused errors in our tests which led us to finding the error.