### PR TITLE
updated to moto ver 1.3.16 and it fixed several failing tests in ndingest.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,5 @@
 fakeredis
 nose2
 
-# 1.3.8 adds cfn-lint which has an dependency on aws-sam-translator 1.11.0
-# which breaks during installation with Python 3.5.
-moto==1.3.7
+# moto 1.3.14 is the first version that supports delete policy 
+moto>=1.3.14

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 fakeredis
 nose2
 
-# moto 1.3.14 is the first version that supports delete policy 
-moto>=1.3.14
+# updating to moto 1.3.16 fixed several tests that were failing. 
+moto>=1.3.16


### PR DESCRIPTION
Previous versions of moto will cause some of our spdb policy tests to fail