### PR TITLE
Fix cutout_to_black Delayed Write Issue

### DIFF
--- a/spdb/spatialdb/annocube.py
+++ b/spdb/spatialdb/annocube.py
@@ -59,6 +59,14 @@ class AnnotateCube64(Cube):
                                       size=[self.time_range[1]-self.time_range[0]] + self.cube_size,
                                       dtype=np.uint64)
 
+    def ones(self):
+        """Create a cube of 1s.
+
+        Return:
+            None
+        """
+        self.data = np.ones([self.time_range[1]-self.time_range[0]] + self.cube_size, dtype=np.uint64, order='C')
+
     def overwrite(self, input_data, time_sample_range=None):
         """ Overwrite data with all non-zero values in the input_data
 

--- a/spdb/spatialdb/cube.py
+++ b/spdb/spatialdb/cube.py
@@ -362,6 +362,15 @@ class Cube(metaclass=ABCMeta):
             None
         """
         return NotImplemented
+    
+    @abstractmethod
+    def ones(self):
+        """Create a cube of 1s, used primarily in testing
+
+        Returns:
+            None
+        """
+        return NotImplemented
 
     @abstractmethod
     def xy_image(self, z_index=0):

--- a/spdb/spatialdb/imagecube.py
+++ b/spdb/spatialdb/imagecube.py
@@ -59,6 +59,14 @@ class ImageCube8(Cube):
         self.data = np.ascontiguousarray(np.random.randint(1, 254,
                                          size=[self.time_range[1]-self.time_range[0]] + self.cube_size,
                                          dtype=self.datatype), dtype=self.datatype)
+    
+    def ones(self):
+        """Create a cube of 1s.
+
+        Return:
+            None
+        """
+        self.data = np.ones([self.time_range[1]-self.time_range[0]] + self.cube_size, dtype=np.uint8, order='C')
 
     def overwrite(self, input_data, time_sample_range=None):
         """ Overwrite data with all non-zero values in the input_data
@@ -178,6 +186,14 @@ class ImageCube16(Cube):
         self.data = np.ascontiguousarray(np.random.randint(1, 65534,
                                          size=[self.time_range[1]-self.time_range[0]] + self.cube_size,
                                          dtype=self.datatype), dtype=self.datatype)
+
+    def ones(self):
+        """Create a cube of 1s.
+
+        Return:
+            None
+        """
+        self.data = np.ones([self.time_range[1]-self.time_range[0]] + self.cube_size, dtype=np.uint16, order='C')
 
     def overwrite(self, input_data, time_sample_range=None):
         """ Overwrite data with all non-zero values in the input_data

--- a/spdb/spatialdb/object.py
+++ b/spdb/spatialdb/object.py
@@ -169,7 +169,7 @@ class ObjectStore(metaclass=ABCMeta):
         raise NotImplemented
 
     @abstractmethod
-    def trigger_page_out(self, config_data, write_cuboid_key, resource, is_black):
+    def trigger_page_out(self, config_data, write_cuboid_key, resource):
         """
         Method to trigger an page out to the object storage system
 
@@ -177,7 +177,6 @@ class ObjectStore(metaclass=ABCMeta):
             config_data (dict): Dictionary of configuration information
             write_cuboid_key (str): Unique write-cuboid to be flushed to S3
             resource (spdb.project.resource.BossResource): resource for the given write cuboid key
-            is_black (bool): message flag for black overwrite
 
         Returns:
             None
@@ -727,7 +726,7 @@ class AWSObjectStore(ObjectStore):
         return self.obj_ind.get_tight_bounding_box(
             cutout_fcn, resource, resolution, id, x_rng, y_rng, z_rng, t_rng)
 
-    def trigger_page_out(self, config_data, write_cuboid_key, resource, to_black=False):
+    def trigger_page_out(self, config_data, write_cuboid_key, resource):
         """
         Method to invoke lambda function to page out via data in an SQS message
 
@@ -735,7 +734,6 @@ class AWSObjectStore(ObjectStore):
             config_data (dict): Dictionary of configuration dictionaries
             write_cuboid_key (str): Unique write-cuboid to be flushed to S3
             resource (spdb.project.resource.BossResource): resource for the given write cuboid key
-            is_black (bool): message flag for black overwrite
 
         Returns:
             None
@@ -746,8 +744,7 @@ class AWSObjectStore(ObjectStore):
         msg_data = {"config": config_data,
                     "write_cuboid_key": write_cuboid_key,
                     "lambda-name": "s3_flush",
-                    "resource": resource.to_dict(),
-                    "to_black": to_black
+                    "resource": resource.to_dict()
                     }
 
         response = sqs.send_message(QueueUrl=self.config["s3_flush_queue"],

--- a/spdb/spatialdb/spatialdb.py
+++ b/spdb/spatialdb/spatialdb.py
@@ -730,6 +730,7 @@ class SpatialDB:
             time_sample_start (int): if cuboid_data.ndim == 3, the time sample for the data
                                      if cuboid_data.ndim == 4, the time sample for cuboid_data[0, :, :, :]
             iso (bool): Flag indicating if you want to write to the "isotropic" version of a channel, if available
+            to_black (bool): Flag indicating is this cuboid is a cutout_to_black cuboid. 
 
         Returns:
             None
@@ -789,9 +790,15 @@ class SpatialDB:
         # Get keys ready
         experiment = resource.get_experiment()
         if iso is True and resolution > resource.get_isotropic_level() and experiment.hierarchy_method.lower() == "anisotropic":
-            base_write_cuboid_key = "WRITE-CUBOID&ISO&{}&{}".format(resource.get_lookup_key(), resolution)
+            if to_black:
+                base_write_cuboid_key = "BLACK-CUBOID&ISO&{}&{}".format(resource.get_lookup_key(), resolution)
+            else:
+                base_write_cuboid_key = "WRITE-CUBOID&ISO${}&{}".format(resource.get_lookup_key(), resolution)
         else:
-            base_write_cuboid_key = "WRITE-CUBOID&{}&{}".format(resource.get_lookup_key(), resolution)
+            if to_black:
+                base_write_cuboid_key = "BLACK-CUBOID&{}&{}".format(resource.get_lookup_key(), resolution)
+            else:
+                base_write_cuboid_key = "WRITE-CUBOID&{}&{}".format(resource.get_lookup_key(), resolution)
 
         log.info("Writing Cuboid - Base Key: {}".format(base_write_cuboid_key))
 
@@ -846,8 +853,7 @@ class SpatialDB:
                                                                 "state_config": self.state_conf,
                                                                 "object_store_config": self.object_store_config},
                                                                write_cuboid_key,
-                                                               resource,
-                                                               to_black)
+                                                               resource)
                                 page_out_cnt += 1
                                 # All done. continue.
                             else:

--- a/spdb/spatialdb/test/int_test_spatialdb.py
+++ b/spdb/spatialdb/test/int_test_spatialdb.py
@@ -416,7 +416,124 @@ class SpatialDBImageDataIntegrationTestMixin(object):
         cube2 = sp.cutout(self.resource, (200, 600, 3), (400, 400, 8), 0, iso=True)
 
         np.testing.assert_array_equal(cube1.data, cube2.data)
+    
+    def test_cutout_to_black_no_time_single_aligned_no_iso(self):
+        """Test the write_cuboid method - to black - no time - single - aligned - no iso"""
+        # Generate random data
+        cube1 = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim])
+        cube1.random()
+        cube1.morton_id = 0
+        
+        cubeb = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim])
+        cubeb.ones()
+        cubeb.morton_id = 0
 
+        sp = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
+
+        # write data cuboid
+        sp.write_cuboid(self.resource, (0, 0, 0), 0, cube1.data)
+
+        # write to_black
+        sp.write_cuboid(self.resource, (0, 0, 0), 0, cubeb.data, to_black=True)
+
+        # get cuboid back
+        cube2 = sp.cutout(
+            self.resource, (0, 0, 0), (self.x_dim, self.y_dim, self.z_dim), 0)
+
+        # expected result
+        cubez = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim])
+        cubez.zeros()
+        cubez.morton_id = 0
+
+        np.testing.assert_array_equal(cube2.data, cubez.data)
+    
+    def test_cutout_to_black_no_time_single_unaligned_no_iso(self):
+        """Test the write_cuboid method - to black - no time - single - unaligned - no iso"""
+        # Generate random data
+        cube1 = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim])
+        cube1.random()
+        cube1.morton_id = 0
+        
+        cubeb = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim//2])
+        cubeb.ones()
+        cubeb.morton_id = 0
+
+        sp = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
+
+        # write data cuboid
+        sp.write_cuboid(self.resource, (0, 0, 0), 0, cube1.data)
+
+        # write to_black
+        sp.write_cuboid(self.resource, (0, 0, 8), 0, cubeb.data, to_black=True)
+
+        # get cuboid back
+        cube2 = sp.cutout(
+            self.resource, (0, 0, 8), (self.x_dim, self.y_dim, self.z_dim), 0)
+
+        # expected result
+        cubez = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim//2])
+        cubez.zeros()
+        cubez.morton_id = 0
+
+        np.testing.assert_array_equal(cube2.data, cubez.data)
+
+    def test_cutout_to_black_no_time_single_aligned_iso(self):
+        """Test the write_cuboid method - to black - no time - single - aligned - iso"""
+        cube1 = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim])
+        cube1.random()
+        cube1.morton_id = 0
+        
+        cubeb = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim])
+        cubeb.ones()
+        cubeb.morton_id = 0
+
+        sp = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
+
+        # write data cuboid
+        sp.write_cuboid(self.resource, (0, 0, 0), 0, cube1.data, iso=True)
+
+        # write to_black
+        sp.write_cuboid(self.resource, (0, 0, 0), 0, cubeb.data, iso=True, to_black=True)
+
+        # get cuboid back
+        cube2 = sp.cutout(
+            self.resource, (0, 0, 0), (self.x_dim, self.y_dim, self.z_dim), 0, iso=True)
+
+        # expected result
+        cubez = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim])
+        cubez.zeros()
+        cubez.morton_id = 0
+
+        np.testing.assert_array_equal(cube2.data, cubez.data)
+    
+    def test_cutout_to_black_time_single_aligned_no_iso(self):
+        """Test the write_cuboid method - to black - time - single - aligned - no iso"""
+        cube1 = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim], time_range=[0, 3])
+        cube1.random()
+        cube1.morton_id = 0
+        
+        cubeb = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim], time_range=[0, 3])
+        cubeb.ones()
+        cubeb.morton_id = 0
+
+        sp = SpatialDB(self.kvio_config, self.state_config, self.object_store_config)
+
+        # write data cuboid
+        sp.write_cuboid(self.resource, (0, 0, 0), 0, cube1.data)
+
+        # write to_black
+        sp.write_cuboid(self.resource, (0, 0, 0), 0, cubeb.data, to_black=True)
+
+        # get cuboid back
+        cube2 = sp.cutout(
+            self.resource, (0, 0, 0), (self.x_dim, self.y_dim, self.z_dim), 0, time_sample_range=[0, 3])
+
+        # expected result
+        cubez = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim], time_range=[0, 3])
+        cubez.zeros()
+        cubez.morton_id = 0
+
+        np.testing.assert_array_equal(cube2.data, cubez.data)
 
 class TestIntegrationSpatialDBImage8Data(SpatialDBImageDataTestMixin,
                                          SpatialDBImageDataIntegrationTestMixin, unittest.TestCase):


### PR DESCRIPTION
As discovered from integration tests on boss (see PR https://github.com/jhuapl-boss/boss/pull/66) there was an issue where delayed writes would not be processed as a cutout_to_black request. I fixed this by instead having the `to_black` flag be part of the write_cuboid_key instead of part of the SQS message. 

See PR for boss: https://github.com/jhuapl-boss/boss/pull/66
See PR for bosstools: https://github.com/jhuapl-boss/boss-tools/pull/43


How it worked before:
1. A user would make a cutout to black request using intern.
2. The endpoint view would process the request and create an array of ones to indicate which voxels are being deleted. 
3. SpatialDB would write a cuboid and do one of two things:
     - if its not in page_out, it would send the sqs message and trigger the s3_flush lambda with the `to_black` flag so it 
     overwrites a cuboid to black. (this path works).
     - if its in page_out, it would send the write key and array of ones to the delayedWrite daemon. The daemon would later 
     process the delayed write but since it doesn't have the `to_black` flag, it processes the array as a normal cutout and 
     replaces data with ones. (this path is what I fixed)

How it works now:
1. A user would make a cutout to black request using intern.
2. The endpoint view would process the request and create an array of ones to indicate which voxels are being deleted. 
3. SpatialDB will write a cuboid and if "to_black" is set to the true the prefix of the write key is `BLACK`. 
    e.g. `BLACK-CUBOID&0&1&2&4&1fndsf4sdklfns3mfs`
4. When the write key is sent to the s3_flush_lambda, it will check for the `BLACK` prefix in the key to indicate its from a cutout_to_black request. 


Since this messes with write keys I took extra precaution and added unittests for spdb to check that it didn't interfere with regular cutout functionality. All tests, including new ones, passed with some minor warnings about resolution mismatch.

Another option I explored was not changing the write cuboid prefix but instead having it as a flag within the key like it is for `ISO`. So a write cuboid from cutout_to_black would be like `WRITE-CUBOID&BLACK&ISO&(rest of key)`. I tried it first this way but this caused a lot of issues since the parts for the key (separated by the &) are hardcoded in a lot of places in spdb. I chose to instead change the prefix instead since that doesn't mess with the object and cache keys. 


