### PR TITLE
Revert "added opencv as a requirement"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,9 @@ commands:
     steps:
       - run: python3 -m unittest
 jobs:
-  test_py3_5:
+  test_py3_8:
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.8
     environment:
       AWS_ACCESS_KEY_ID: testing
       AWS_SECRET_ACCESS_KEY: testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,9 @@ commands:
     steps:
       - run: python3 -m unittest
 jobs:
-  test_py3_8:
+  test_py3_5:
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.5
     environment:
       AWS_ACCESS_KEY_ID: testing
       AWS_SECRET_ACCESS_KEY: testing
@@ -40,4 +40,4 @@ workflows:
   version: 2
   test:
     jobs:
-      - test_py3_8
+      - test_py3_5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,4 +40,4 @@ workflows:
   version: 2
   test:
     jobs:
-      - test_py3_5
+      - test_py3_8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Pillow>=4.1.1
-opencv-python>=4.5.1.48
 redis>=2.10.5
 
 # blosc 1.7.0 fails intermittently in the lambda environment.  Pinning at


### PR DESCRIPTION
Reverts jhuapl-boss/spdb#25
Since cv added 77MB to the lambda it is too large to build. Reverting this change until we figure out a way forward.

Keeping the update to circleci to python3.8

https://github.com/jhuapl-boss/boss-tools/pull/45
