### PR TITLE
Add cutout_to_black integration tests

### DIFF
--- a/spdb/spatialdb/kvio.py
+++ b/spdb/spatialdb/kvio.py
@@ -108,6 +108,34 @@ class KVIO(metaclass=ABCMeta):
         # Return a list of all keys
         return ['{}&{}&{}&{}'.format(base_key, s[0], s[1], uuid.uuid4().__str__()) for s in key_suffix_list]
 
+    def generate_black_cuboid_keys(self, resource, resolution, time_sample_list, morton_idx_list):
+        """Generate Keys for black cuboids from cutout_to_black that are in the WRITE BUFFER of the 
+        redis cache db
+
+        The keys are ordered by time sample followed by morton ID (e.g. 1&1, 1&2, 1&3, 2&1, 2&2, 2&3)
+
+        The key contains the base lookup key with the time samples and morton ids appended with the format:
+
+            BLACK-CUBOID&{lookup_key}&time_sample&morton_id&UUID
+
+        Args:
+            resource (spdb.project.BossResource): Data model info based on the request or target resource
+            resolution (int): the resolution level
+            morton_idx_list (list[int]): a list of Morton ID of the cuboids to get
+            time_sample_list (list[int]): a list of time samples of the cuboids to get
+
+        Returns:
+            list[str]: A list of keys for each cuboid
+
+        """
+        base_key = 'BLACK-CUBOID&{}&{}'.format(resource.get_lookup_key(), resolution)
+
+        # Get the combinations of time and morton, properly ordered
+        key_suffix_list = itertools.product(time_sample_list, morton_idx_list)
+
+        # Return a list of all keys
+        return ['{}&{}&{}&{}'.format(base_key, s[0], s[1], uuid.uuid4().__str__()) for s in key_suffix_list]
+
     def write_cuboid_key_to_cache_key(self, write_cuboid_key):
         """Converts a write cuboid key to a cache key
 

--- a/spdb/spatialdb/rediskvio.py
+++ b/spdb/spatialdb/rediskvio.py
@@ -259,7 +259,9 @@ class RedisKVIO(KVIO):
 
     def is_dirty(self, cache_key_list):
         """
-        Check if a cuboid is dirty based on its cache key
+        Check if a cuboid is dirty based on its cache key.
+
+        TODO: Is it possible for a black cuboid to get dirty? 
         Args:
             cache_key_list (list(str)): A list of cached-cuboid keys
 

--- a/spdb/spatialdb/test/int_test_spatialdb.py
+++ b/spdb/spatialdb/test/int_test_spatialdb.py
@@ -454,6 +454,7 @@ class SpatialDBImageDataIntegrationTestMixin(object):
         cube1.random()
         cube1.morton_id = 0
         
+        # Only blacking out half the cuboid.
         cubeb = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim//2])
         cubeb.ones()
         cubeb.morton_id = 0
@@ -464,18 +465,17 @@ class SpatialDBImageDataIntegrationTestMixin(object):
         sp.write_cuboid(self.resource, (0, 0, 0), 0, cube1.data)
 
         # write to_black
-        sp.write_cuboid(self.resource, (0, 0, 8), 0, cubeb.data, to_black=True)
+        sp.write_cuboid(self.resource, (0, 0, 0), 0, cubeb.data, to_black=True)
 
         # get cuboid back
         cube2 = sp.cutout(
-            self.resource, (0, 0, 8), (self.x_dim, self.y_dim, self.z_dim), 0)
+            self.resource, (0, 0, 0), (self.x_dim, self.y_dim, self.z_dim), 0)
 
         # expected result
-        cubez = Cube.create_cube(self.resource, [self.x_dim, self.y_dim, self.z_dim//2])
-        cubez.zeros()
-        cubez.morton_id = 0
+        expected_data = cube1.data
+        expected_data[:, :self.z_dim//2, :, :] = 0
 
-        np.testing.assert_array_equal(cube2.data, cubez.data)
+        np.testing.assert_array_equal(cube2.data, expected_data)
 
     def test_cutout_to_black_no_time_single_aligned_iso(self):
         """Test the write_cuboid method - to black - no time - single - aligned - iso"""

--- a/spdb/spatialdb/test/int_test_spatialdb.py
+++ b/spdb/spatialdb/test/int_test_spatialdb.py
@@ -472,7 +472,7 @@ class SpatialDBImageDataIntegrationTestMixin(object):
             self.resource, (0, 0, 0), (self.x_dim, self.y_dim, self.z_dim), 0)
 
         # expected result
-        expected_data = cube1.data
+        expected_data = np.copy(cube1.data)
         expected_data[:, :self.z_dim//2, :, :] = 0
 
         np.testing.assert_array_equal(cube2.data, expected_data)

--- a/spdb/spatialdb/test/test_rediskvio.py
+++ b/spdb/spatialdb/test/test_rediskvio.py
@@ -54,6 +54,21 @@ class RedisKVIOTestMixin(object):
         assert keys[5].rsplit("&", 1)[0] == "WRITE-CUBOID&4&3&2&2&1&36"
         assert keys[8].rsplit("&", 1)[0] == "WRITE-CUBOID&4&3&2&2&2&36"
 
+    def test_generate_black_cuboid_keys(self):
+        """Test if black-cuboid keys are formatted properly"""
+        rkv = RedisKVIO(self.config_data)
+        keys = rkv.generate_black_cuboid_keys(self.resource, 2, [0, 1, 2], [34, 35, 36])
+        assert len(keys) == 9
+        uuids = []
+        for key in keys:
+            uuids.append(key.rsplit("&", 1)[1])
+        assert len(set(uuids)) == 9
+
+        assert keys[0].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&0&34"
+        assert keys[2].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&0&36"
+        assert keys[5].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&1&36"
+        assert keys[8].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&2&36"
+
     def test_get_missing_read_cache_keys(self):
         """Test for querying for keys missing in the cache"""
         # Put some keys in the cache

--- a/spdb/spatialdb/test/test_rediskvio.py
+++ b/spdb/spatialdb/test/test_rediskvio.py
@@ -65,8 +65,13 @@ class RedisKVIOTestMixin(object):
         assert len(set(uuids)) == 9
 
         assert keys[0].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&0&34"
+        assert keys[1].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&0&35"
         assert keys[2].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&0&36"
+        assert keys[3].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&1&34"
+        assert keys[4].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&1&35"
         assert keys[5].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&1&36"
+        assert keys[6].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&2&34"
+        assert keys[7].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&2&35"
         assert keys[8].rsplit("&", 1)[0] == "BLACK-CUBOID&4&3&2&2&2&36"
 
     def test_get_missing_read_cache_keys(self):


### PR DESCRIPTION
This PR adds an additional unit and integration tests.

After merging the cutout-to-black fixes (https://github.com/jhuapl-boss/spdb/pull/24),  I wanted to create more robust tests to ensure that modifying the write_cuboid_keys does not affect cache and delayed write operations. 

From what I can see, the current rediskvio does not have to be modified since the modification to the write_cuboid_key does not change the parsing of its individual components. What I mean by that is that traditionally a write cuboid key would be something like 

`WRITE-CUBOID&{lookup_key}&time_sample&morton_id&UUID`

The KVIO functions split the key by the `&` characters and get the information it needs to construct the cache key. For black-upload cuboids the same structure is used but just a different prefix.

`BLACK-CUBOID&{lookup_key}&time_sample&morton_id&UUID`

Since the information order is preserved, KVIO works with these keys without any issues. The lambda can then identify its a black cuboid from the prefix. However, from these tests I did find a bug in s3_flush lambda that I will submit another PR for!