### PR TITLE
Feature: Add cuboids_from_id functionality

### DIFF
--- a/spdb/spatialdb/object.py
+++ b/spdb/spatialdb/object.py
@@ -248,6 +248,22 @@ class ObjectStore(metaclass=ABCMeta):
         """
         raise NotImplemented
 
+    @abstractmethod
+    def get_cuboids_from_id(self, resource, resolution, id, version=0):
+        """
+        Method to get cuboids that belong to a particular ID.
+
+        Args:
+            resource (project.BossResource): Data model info based on the request or target resource
+            resolution (int): the resolution level
+            id (int): id of interest.
+            version (optional[int]): Reserved for future use.  Defaults to 0
+        
+        Returns:
+            (dict) : {'cuboids': [(1, 3, 4), (2, 0, 1), (4, 60, 20)]}
+        """
+        raise NotImplemented
+
 
 class AWSObjectStore(ObjectStore):
     def __init__(self, conf):
@@ -829,6 +845,21 @@ class AWSObjectStore(ObjectStore):
         ids_as_str = ['%d' % n for n in id_set]
 
         return { 'ids': ids_as_str }
+    
+    def get_cuboids_from_id(self, resource, resolution, id, version=0):
+        """
+        Method to get cuboids that belong to a particular ID.
+
+        Args:
+            resource (project.BossResource): Data model info based on the request or target resource
+            resolution (int): the resolution level
+            id (int): id of interest.
+            version (optional[int]): Reserved for future use.  Defaults to 0
+        
+        Returns:
+            (dict) : {'cuboids': [(512, 512, 32), (512, 512, 1), (4, 60, 20)]}
+        """
+        return self.obj_ind.get_cuboids_from_id(resource, resolution, id, version)
 
     def _get_ids_from_cutout(
             self, cutout_fcn, resource, resolution, corner, extent,

--- a/spdb/spatialdb/object.py
+++ b/spdb/spatialdb/object.py
@@ -857,7 +857,7 @@ class AWSObjectStore(ObjectStore):
             version (optional[int]): Reserved for future use.  Defaults to 0
         
         Returns:
-            (dict) : {'cuboids': [(512, 512, 32), (512, 512, 1), (4, 60, 20)]}
+            (dict) : Corners of cuboids containing ID. Ex: {'cuboids': [[512, 512, 64], [0, 512, 32], [512, 512, 32]}
         """
         return self.obj_ind.get_cuboids_from_id(resource, resolution, id, version)
 

--- a/spdb/spatialdb/object_indices.py
+++ b/spdb/spatialdb/object_indices.py
@@ -1082,7 +1082,7 @@ class ObjectIndices:
             id (uint64|string): object's id
             version (optional[int]): Version - reserved for future use.
         Returns:
-            (dict|None): {'cuboids': [512,512,16]} or None if the id is not found.
+           (dict|None) : Corners of cuboids containing ID or None if the id is not found.
 
         Raises:
             (SpdbError): Can't talk to id index database or database corrupt.

--- a/spdb/spatialdb/spatialdb.py
+++ b/spdb/spatialdb/spatialdb.py
@@ -969,10 +969,11 @@ class SpatialDB:
 
         Args:
             resource (spdb.project.resource.BossResource): Data model info based on the request or target resource.
+            resolution (int): the resolution level
             id (uint64|string): object's id
             version (optional[int]): Defaults to zero, reserved for future use.
 
         Returns:
-            (np.array): starting ID for the block of ID successfully reserved as a numpy array to insure uint64
+            (dict) : Corners of cuboids containing ID. Ex: {'cuboids': [[512, 512, 64], [0, 512, 32], [512, 512, 32]}
         """
         return self.objectio.get_cuboids_from_id(resource, resolution, int(id), version)

--- a/spdb/spatialdb/spatialdb.py
+++ b/spdb/spatialdb/spatialdb.py
@@ -964,4 +964,15 @@ class SpatialDB:
         """
         return self.objectio.reserve_ids(resource, num_ids, version)
 
+    def get_cuboids_from_id(self, resource, resolution, id, version=0):
+        """Method to get cuboid indicies for a particular ID
 
+        Args:
+            resource (spdb.project.resource.BossResource): Data model info based on the request or target resource.
+            id (uint64|string): object's id
+            version (optional[int]): Defaults to zero, reserved for future use.
+
+        Returns:
+            (np.array): starting ID for the block of ID successfully reserved as a numpy array to insure uint64
+        """
+        return self.objectio.get_cuboids_from_id(resource, resolution, int(id), version)


### PR DESCRIPTION
**Draft PR because I haven't added tests.** 

For applications in proofreading and meshing it's useful to have a way to get the cuboids that specifically belong to one ID. This functionality existed as an intermediate product of indexing and bounding boxes, so I just yanked some of that code to create a `cuboid_from_id()` function that returns the list of cuboid corners that contain a particular ID. 

Essentially the function lives in the `object_ind.py` function and its inputs are a BossResource, resolution, and ID. It returns a dict object with a single fixed keyword, `cuboids` and the value is a list of tuples containing cuboid corners in X,Y,Z format. 

boss PR: 

