### PR TITLE
Pillow req fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# Pillow is pinned here because 8.3.0 had an error that caused tile_ingest_lambda to fail
+# https://pillow.readthedocs.io/en/stable/releasenotes/8.3.1.html#fixed-regression-converting-to-numpy-arrays
 Pillow>=8.3.1
 redis>=2.10.5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Pillow>=4.1.1
+Pillow>=8.3.1
 redis>=2.10.5
 
 # blosc 1.7.0 fails intermittently in the lambda environment.  Pinning at


### PR DESCRIPTION
…ich caused problems for tile-ingest-lambda.

Updated because of this:
https://pillow.readthedocs.io/en/stable/releasenotes/8.3.1.html#fixed-regression-converting-to-numpy-arrays

also see: https://github.com/jhuapl-boss/ingest-client/pull/56