### PR TITLE
Switch Dynamo tables to on demand billing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.o
 
 # Distribution / packaging
 .Python

--- a/spdb/spatialdb/dynamo/id_count_schema.json
+++ b/spdb/spatialdb/dynamo/id_count_schema.json
@@ -19,8 +19,5 @@
             "AttributeType": "N"
         }
     ],
-    "ProvisionedThroughput":{
-        "ReadCapacityUnits": 10,
-        "WriteCapacityUnits": 10
-    }
+    "BillingMode": "PAY_PER_REQUEST"
 }

--- a/spdb/spatialdb/dynamo/id_index_schema.json
+++ b/spdb/spatialdb/dynamo/id_index_schema.json
@@ -34,15 +34,8 @@
             ],
             "Projection": {
                 "ProjectionType": "KEYS_ONLY"
-            },
-            "ProvisionedThroughput": {
-                "ReadCapacityUnits": 15,
-                "WriteCapacityUnits": 15
             }
         }
     ],
-    "ProvisionedThroughput":{
-        "ReadCapacityUnits": 15,
-        "WriteCapacityUnits": 15
-    }
+    "BillingMode": "PAY_PER_REQUEST"
 }

--- a/spdb/spatialdb/dynamo/s3_index_table.json
+++ b/spdb/spatialdb/dynamo/s3_index_table.json
@@ -34,15 +34,8 @@
             ],
             "Projection": {
                 "ProjectionType": "KEYS_ONLY"
-            },
-            "ProvisionedThroughput": {
-                "ReadCapacityUnits": 15,
-                "WriteCapacityUnits": 15
             }
         }
     ],
-    "ProvisionedThroughput": {
-        "ReadCapacityUnits": 15,
-        "WriteCapacityUnits": 15
-    }
+    "BillingMode": "PAY_PER_REQUEST"
 }


### PR DESCRIPTION
On demand has been in use on bossDB for a while.  Formally switch this
for the tables controlled by this repo.

Also gitignore .o files.

## Related PRs:
* https://github.com/jhuapl-boss/boss-manage/pull/107 (required because this makes `ProvisionedCapacity` optional)
* https://github.com/jhuapl-boss/boss-tools/pull/56