### PR TITLE
Changed Exception to RuntimeError

### DIFF
--- a/spdb/project/resource.py
+++ b/spdb/project/resource.py
@@ -34,7 +34,7 @@ def get_isotropic_level(hierarchy_method, x_voxel_size, y_voxel_size, z_voxel_si
             return 0
         else:
             if x_voxel_size != y_voxel_size:
-                raise Exception("X voxel size != Y voxel size. Currently unable to determine isotropic level")
+                raise RuntimeError("X voxel size != Y voxel size. Currently unable to determine isotropic level")
 
             aspect_ratios = [float(z_voxel_size) / (x_voxel_size * 2 ** r) for r in range(0, 30)]
             resolution = (np.abs(np.array(aspect_ratios)-1)).argmin()

--- a/spdb/project/resource.py
+++ b/spdb/project/resource.py
@@ -34,7 +34,7 @@ def get_isotropic_level(hierarchy_method, x_voxel_size, y_voxel_size, z_voxel_si
             return 0
         else:
             if x_voxel_size != y_voxel_size:
-                raise RuntimeError("X voxel size != Y voxel size. Currently unable to determine isotropic level")
+                raise ValueError("X voxel size != Y voxel size. Currently unable to determine isotropic level")
 
             aspect_ratios = [float(z_voxel_size) / (x_voxel_size * 2 ** r) for r in range(0, 30)]
             resolution = (np.abs(np.array(aspect_ratios)-1)).argmin()


### PR DESCRIPTION
This change was made in conjunction with:

https://github.com/jhuapl-boss/boss/pull/93/files#diff-249f2d3f01d910b39cd8e8df4a9e35cb0d483aa16050f384d9a87b6a138e1408

When a runtime error is raised here, a runtime error can be caught in the boss script referenced rather than a generic exception